### PR TITLE
feat: F-003 Model 設定表格檢視

### DIFF
--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-table": "^8.20.0",
+        "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.0",
         "lucide-react": "^0.500.0",
         "next": "^16.2.0",
         "postgres": "^3.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.5.0",
         "ts-morph": "^24.0.0",
         "zod": "^3.24.0"
       },
@@ -4258,6 +4260,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -5126,6 +5137,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8238,6 +8250,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -16,12 +16,14 @@
   },
   "dependencies": {
     "@tanstack/react-table": "^8.20.0",
+    "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.0",
     "lucide-react": "^0.500.0",
     "next": "^16.2.0",
     "postgres": "^3.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.5.0",
     "ts-morph": "^24.0.0",
     "zod": "^3.24.0"
   },

--- a/dev/src/app/api/v1/settings/[settingId]/route.ts
+++ b/dev/src/app/api/v1/settings/[settingId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { successResponse, errorResponse } from "@/lib/api";
+import { getSettingById } from "@/lib/queries/settings";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ settingId: string }> }
+) {
+  try {
+    const { settingId } = await params;
+
+    const setting = await getSettingById(settingId);
+    if (!setting) {
+      return errorResponse("NOT_FOUND", "Setting not found", 404);
+    }
+
+    return successResponse(setting);
+  } catch (error) {
+    console.error("Failed to fetch setting:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to fetch setting", 500);
+  }
+}

--- a/dev/src/app/api/v1/settings/route.ts
+++ b/dev/src/app/api/v1/settings/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { successResponse, errorResponse } from "@/lib/api";
+import { getVersionById } from "@/lib/queries/versions";
+import { querySettings } from "@/lib/queries/settings";
+
+const querySchema = z.object({
+  version_id: z.string().uuid("version_id must be a valid UUID"),
+  environment_id: z.string().uuid().optional(),
+  edition_id: z.string().uuid().optional(),
+  model_type: z.string().optional(),
+  deploy_only: z
+    .string()
+    .optional()
+    .transform((v) => v === "true"),
+  search: z.string().optional(),
+  sort_by: z.enum(["name", "type", "deploy", "replica", "gpu_memory_utilization"]).default("name"),
+  sort_order: z.enum(["asc", "desc"]).default("asc"),
+  page: z
+    .string()
+    .optional()
+    .transform((v) => Math.max(1, parseInt(v ?? "1", 10))),
+  per_page: z
+    .string()
+    .optional()
+    .transform((v) => Math.min(200, Math.max(1, parseInt(v ?? "50", 10)))),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = Object.fromEntries(
+      request.nextUrl.searchParams.entries()
+    );
+
+    // Validate version_id is present
+    if (!searchParams.version_id) {
+      return errorResponse(
+        "INVALID_INPUT",
+        "version_id is required",
+        400
+      );
+    }
+
+    const parseResult = querySchema.safeParse(searchParams);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors.map((e) => e.message).join(", "),
+        400
+      );
+    }
+
+    const query = parseResult.data;
+
+    // Check version exists
+    const version = await getVersionById(query.version_id);
+    if (!version) {
+      return errorResponse("NOT_FOUND", "Version not found", 404);
+    }
+
+    const result = await querySettings({
+      versionId: query.version_id,
+      environmentId: query.environment_id,
+      editionId: query.edition_id,
+      modelType: query.model_type,
+      deployOnly: query.deploy_only,
+      search: query.search,
+      sortBy: query.sort_by,
+      sortOrder: query.sort_order,
+      page: query.page,
+      perPage: query.per_page,
+    });
+
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch settings:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to fetch settings", 500);
+  }
+}

--- a/dev/src/app/api/v1/versions/[versionId]/editions/route.ts
+++ b/dev/src/app/api/v1/versions/[versionId]/editions/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from "next/server";
+import { successResponse, errorResponse } from "@/lib/api";
+import { getVersionById, getEditionsByVersionId } from "@/lib/queries/versions";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ versionId: string }> }
+) {
+  try {
+    const { versionId } = await params;
+
+    const version = await getVersionById(versionId);
+    if (!version) {
+      return errorResponse("NOT_FOUND", "Version not found", 404);
+    }
+
+    const result = await getEditionsByVersionId(versionId);
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch editions:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to fetch editions", 500);
+  }
+}

--- a/dev/src/app/api/v1/versions/[versionId]/environments/route.ts
+++ b/dev/src/app/api/v1/versions/[versionId]/environments/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { successResponse, errorResponse } from "@/lib/api";
+import {
+  getVersionById,
+  getEnvironmentsByVersionId,
+} from "@/lib/queries/versions";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ versionId: string }> }
+) {
+  try {
+    const { versionId } = await params;
+
+    const version = await getVersionById(versionId);
+    if (!version) {
+      return errorResponse("NOT_FOUND", "Version not found", 404);
+    }
+
+    const result = await getEnvironmentsByVersionId(versionId);
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch environments:", error);
+    return errorResponse(
+      "INTERNAL_ERROR",
+      "Failed to fetch environments",
+      500
+    );
+  }
+}

--- a/dev/src/app/api/v1/versions/route.ts
+++ b/dev/src/app/api/v1/versions/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+import { successResponse, errorResponse } from "@/lib/api";
+import { queryVersions } from "@/lib/queries/versions";
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+    const perPage = Math.min(
+      100,
+      Math.max(1, parseInt(searchParams.get("per_page") ?? "20", 10))
+    );
+
+    const result = await queryVersions({ page, perPage });
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch versions:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to fetch versions", 500);
+  }
+}

--- a/dev/src/app/page.tsx
+++ b/dev/src/app/page.tsx
@@ -1,24 +1,29 @@
+"use client";
+
+import { VersionSelector } from "@/components/version-selector";
+import { useVersions } from "@/hooks/use-versions";
+
 export default function DashboardPage() {
+  const { versions, isLoading, error } = useVersions();
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-      <p className="mt-2 text-gray-600">
-        Sync Model GP - Model 設定管理平台
-      </p>
-      <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        <div className="rounded-lg border bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold text-gray-900">Versions</h2>
-          <p className="mt-1 text-sm text-gray-500">管理版本設定</p>
-        </div>
-        <div className="rounded-lg border bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold text-gray-900">Environments</h2>
-          <p className="mt-1 text-sm text-gray-500">管理環境設定</p>
-        </div>
-        <div className="rounded-lg border bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold text-gray-900">Editions</h2>
-          <p className="mt-1 text-sm text-gray-500">管理版本方案</p>
-        </div>
+    <div className="mx-auto max-w-[1400px] space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+          版本清單
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          選擇版本以檢視 Model 設定
+        </p>
       </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <VersionSelector versions={versions} isLoading={isLoading} />
     </div>
   );
 }

--- a/dev/src/app/settings/page.tsx
+++ b/dev/src/app/settings/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { SettingsTable } from "@/components/settings-table";
+import { EnvironmentTabs } from "@/components/environment-tabs";
+import { EditionFilter } from "@/components/edition-filter";
+import { ModelTypeBadge } from "@/components/model-type-badge";
+import { useSettings } from "@/hooks/use-settings";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Search, X, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+const ALL_MODEL_TYPES = [
+  "LLM",
+  "VLM",
+  "ASR",
+  "TTS",
+  "Retriever",
+  "Reranker",
+  "ObjectDetection",
+  "ObjectRecognition",
+  "Face",
+  "Guardian",
+] as const;
+
+export default function SettingsPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Read URL state
+  const versionId = searchParams.get("version_id") ?? "";
+  const environmentId = searchParams.get("environment_id") ?? undefined;
+  const editionId = searchParams.get("edition_id") ?? undefined;
+  const modelType = searchParams.get("model_type") ?? undefined;
+  const deployOnly = searchParams.get("deploy_only") === "true";
+  const search = searchParams.get("search") ?? "";
+  const sortBy = searchParams.get("sort_by") ?? "name";
+  const sortOrder = (searchParams.get("sort_order") ?? "asc") as "asc" | "desc";
+  const page = parseInt(searchParams.get("page") ?? "1", 10);
+  const perPage = parseInt(searchParams.get("per_page") ?? "50", 10);
+
+  // Local search input state (for debounce)
+  const [searchInput, setSearchInput] = useState(search);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Sync search input when URL changes externally
+  useEffect(() => {
+    setSearchInput(search);
+  }, [search]);
+
+  // Fetch data
+  const { data, pagination, filters, isLoading, error } = useSettings({
+    versionId,
+    environmentId,
+    editionId,
+    modelType,
+    deployOnly,
+    search: search || undefined,
+    sortBy,
+    sortOrder,
+    page,
+    perPage,
+  });
+
+  // URL update helper
+  const updateParams = useCallback(
+    (updates: Record<string, string | undefined>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === undefined || value === "") {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      }
+      // Reset page to 1 on filter changes (unless explicitly changing page)
+      if (!("page" in updates)) {
+        params.set("page", "1");
+      }
+      router.push(`/settings?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, router]
+  );
+
+  // Debounced search
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        updateParams({ search: value || undefined });
+      }, 300);
+    },
+    [updateParams]
+  );
+
+  // Clear all filters
+  const clearFilters = useCallback(() => {
+    const params = new URLSearchParams();
+    params.set("version_id", versionId);
+    params.set("page", "1");
+    params.set("per_page", String(perPage));
+    router.push(`/settings?${params.toString()}`, { scroll: false });
+    setSearchInput("");
+  }, [versionId, perPage, router]);
+
+  const hasFilters =
+    !!environmentId ||
+    !!editionId ||
+    !!modelType ||
+    deployOnly ||
+    !!search;
+
+  // No version selected state
+  if (!versionId) {
+    return (
+      <div className="mx-auto max-w-[1400px] space-y-6">
+        <div className="flex h-60 items-center justify-center rounded-lg border border-dashed border-slate-300 dark:border-slate-700">
+          <div className="text-center">
+            <p className="text-sm text-slate-500">
+              請先從版本清單選擇一個版本
+            </p>
+            <Link href="/">
+              <Button variant="outline" className="mt-4">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                回到版本清單
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="mx-auto max-w-[1400px] space-y-6">
+        <nav className="text-sm text-slate-500">
+          <Link
+            href="/"
+            className="hover:text-slate-700 dark:hover:text-slate-300"
+          >
+            版本清單
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-900 dark:text-slate-100">設定表格</span>
+        </nav>
+        <div className="flex h-40 items-center justify-center rounded-lg border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20">
+          <div className="text-center">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            <Link href="/">
+              <Button variant="outline" className="mt-4">
+                返回版本清單
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-[1400px] space-y-6">
+      {/* Breadcrumb */}
+      <nav className="text-sm text-slate-500">
+        <Link
+          href="/"
+          className="hover:text-slate-700 dark:hover:text-slate-300"
+        >
+          版本清單
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-slate-900 dark:text-slate-100">設定表格</span>
+      </nav>
+
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+          設定表格
+        </h1>
+        {pagination && (
+          <span className="text-sm text-slate-500">
+            {pagination.total} 筆設定
+          </span>
+        )}
+      </div>
+
+      {/* Filter row */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Environment */}
+        <EnvironmentTabs
+          environments={filters?.available_environments ?? []}
+          selectedId={environmentId}
+          onSelect={(id) => updateParams({ environment_id: id })}
+        />
+
+        {/* Edition */}
+        <EditionFilter
+          editions={filters?.available_editions ?? []}
+          selectedId={editionId}
+          onSelect={(id) => updateParams({ edition_id: id })}
+        />
+
+        {/* Model Type */}
+        <Select
+          value={modelType ?? "all"}
+          onValueChange={(v) =>
+            updateParams({ model_type: v === "all" ? undefined : v })
+          }
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Model Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">全部類型</SelectItem>
+            {(filters?.available_types ?? ALL_MODEL_TYPES).map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="搜尋 model..."
+            value={searchInput}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="w-[200px] pl-9"
+          />
+        </div>
+
+        {/* Deploy only toggle */}
+        <div className="flex items-center gap-2">
+          <Switch
+            id="deploy-only"
+            checked={deployOnly}
+            onCheckedChange={(checked) =>
+              updateParams({ deploy_only: checked ? "true" : undefined })
+            }
+          />
+          <label htmlFor="deploy-only" className="text-sm text-slate-600 dark:text-slate-400">
+            只顯示已部署
+          </label>
+        </div>
+
+        {/* Clear filters */}
+        {hasFilters && (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            <X className="mr-1 h-4 w-4" />
+            清除篩選
+          </Button>
+        )}
+      </div>
+
+      {/* Table */}
+      <SettingsTable
+        data={data}
+        pagination={
+          pagination ?? {
+            page: 1,
+            per_page: perPage,
+            total: 0,
+            total_pages: 1,
+          }
+        }
+        isLoading={isLoading}
+        onPageChange={(p) => updateParams({ page: String(p) })}
+        onPerPageChange={(pp) =>
+          updateParams({ per_page: String(pp), page: "1" })
+        }
+        onSortingChange={(sb, so) =>
+          updateParams({ sort_by: sb, sort_order: so })
+        }
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+      />
+    </div>
+  );
+}

--- a/dev/src/components/edition-filter.tsx
+++ b/dev/src/components/edition-filter.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tag } from "lucide-react";
+
+interface Edition {
+  id: string;
+  name: string;
+}
+
+interface EditionFilterProps {
+  editions: Edition[];
+  selectedId?: string;
+  onSelect: (editionId: string | undefined) => void;
+  disabled?: boolean;
+}
+
+export function EditionFilter({
+  editions,
+  selectedId,
+  onSelect,
+  disabled = false,
+}: EditionFilterProps) {
+  return (
+    <Select
+      value={selectedId ?? "all"}
+      onValueChange={(value) => onSelect(value === "all" ? undefined : value)}
+      disabled={disabled}
+    >
+      <SelectTrigger className="w-[140px]">
+        <div className="flex items-center gap-2">
+          <Tag className="h-4 w-4 text-slate-400" />
+          <SelectValue placeholder="Edition" />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">全部 Edition</SelectItem>
+        {editions.map((edition) => (
+          <SelectItem key={edition.id} value={edition.id}>
+            {edition.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/dev/src/components/environment-tabs.tsx
+++ b/dev/src/components/environment-tabs.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Server } from "lucide-react";
+
+interface Environment {
+  id: string;
+  name: string;
+}
+
+interface EnvironmentTabsProps {
+  environments: Environment[];
+  selectedId?: string;
+  onSelect: (environmentId: string | undefined) => void;
+  disabled?: boolean;
+}
+
+export function EnvironmentTabs({
+  environments,
+  selectedId,
+  onSelect,
+  disabled = false,
+}: EnvironmentTabsProps) {
+  return (
+    <Select
+      value={selectedId ?? "all"}
+      onValueChange={(value) => onSelect(value === "all" ? undefined : value)}
+      disabled={disabled}
+    >
+      <SelectTrigger className="w-[160px]">
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 text-slate-400" />
+          <SelectValue placeholder="Environment" />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">全部環境</SelectItem>
+        {environments.map((env) => (
+          <SelectItem key={env.id} value={env.id}>
+            {env.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/dev/src/components/model-type-badge.tsx
+++ b/dev/src/components/model-type-badge.tsx
@@ -1,0 +1,50 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ModelType } from "@/types";
+
+const MODEL_TYPE_STYLES: Record<ModelType, string> = {
+  LLM: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  ASR: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  TTS: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
+  VLM: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  Retriever:
+    "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300",
+  Reranker:
+    "bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300",
+  ObjectDetection:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300",
+  ObjectRecognition:
+    "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300",
+  Face: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+  Guardian:
+    "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300",
+};
+
+interface ModelTypeBadgeProps {
+  type: string;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function ModelTypeBadge({
+  type,
+  size = "sm",
+  className,
+}: ModelTypeBadgeProps) {
+  const styles = MODEL_TYPE_STYLES[type as ModelType] ?? "bg-slate-100 text-slate-700";
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-transparent font-mono font-medium tracking-wide",
+        size === "sm" && "px-1.5 py-0.5 text-[10px]",
+        size === "md" && "px-2 py-0.5 text-xs",
+        styles,
+        className
+      )}
+    >
+      {type}
+    </Badge>
+  );
+}

--- a/dev/src/components/settings-detail.tsx
+++ b/dev/src/components/settings-detail.tsx
@@ -1,0 +1,99 @@
+import { Badge } from "@/components/ui/badge";
+import { ModelTypeBadge } from "@/components/model-type-badge";
+import { cn } from "@/lib/utils";
+import type { SettingRow } from "@/components/settings-table";
+
+interface SettingsDetailProps {
+  setting: SettingRow;
+  className?: string;
+}
+
+export function SettingsDetail({ setting, className }: SettingsDetailProps) {
+  const { model_component, environment, edition, deploy, gpu_list, replica, gpu_memory_utilization, extra_settings, updated_at } = setting;
+
+  return (
+    <div className={cn("space-y-4 rounded-lg border p-4", className)}>
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="font-mono text-base font-semibold">
+            {model_component.name}
+          </h3>
+          {model_component.component_version && (
+            <p className="mt-0.5 font-mono text-xs text-slate-400">
+              v{model_component.component_version}
+            </p>
+          )}
+        </div>
+        <ModelTypeBadge type={model_component.type} size="md" />
+      </div>
+
+      {/* Deploy status */}
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-block h-2 w-2 rounded-full",
+            deploy ? "bg-green-500" : "bg-slate-400"
+          )}
+        />
+        <span className="text-sm">{deploy ? "已部署" : "未部署"}</span>
+        <span className="text-xs text-slate-400">
+          {environment.name} / {edition.name}
+        </span>
+      </div>
+
+      {/* GPU info */}
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <span className="text-xs text-slate-500">GPU List</span>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {gpu_list.length > 0 ? (
+              gpu_list.map((gpu, i) => (
+                <Badge key={i} variant="secondary" className="font-mono text-xs">
+                  {gpu}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-xs text-slate-400">-</span>
+            )}
+          </div>
+        </div>
+        <div>
+          <span className="text-xs text-slate-500">Replica</span>
+          <p className="mt-1 font-mono">{replica}</p>
+        </div>
+        <div>
+          <span className="text-xs text-slate-500">GPU Memory Utilization</span>
+          <p className="mt-1 font-mono">
+            {gpu_memory_utilization !== null
+              ? `${(gpu_memory_utilization * 100).toFixed(0)}%`
+              : "-"}
+          </p>
+        </div>
+        {model_component.image && (
+          <div>
+            <span className="text-xs text-slate-500">Image</span>
+            <p className="mt-1 break-all font-mono text-xs">
+              {model_component.image}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Extra settings */}
+      {extra_settings && Object.keys(extra_settings).length > 0 && (
+        <div>
+          <span className="text-xs text-slate-500">Extra Settings</span>
+          <pre className="mt-1 overflow-auto rounded bg-slate-50 p-2 font-mono text-xs dark:bg-slate-900">
+            {JSON.stringify(extra_settings, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {/* Updated at */}
+      <div className="text-xs text-slate-400">
+        更新時間: {new Date(updated_at).toLocaleString("zh-TW")}
+      </div>
+    </div>
+  );
+}

--- a/dev/src/components/settings-table.tsx
+++ b/dev/src/components/settings-table.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import React from "react";
+import {
+  ColumnDef,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  ExpandedState,
+  getExpandedRowModel,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { ModelTypeBadge } from "@/components/model-type-badge";
+import {
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronRight as ChevronRightIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// Types
+export interface SettingRow {
+  id: string;
+  model_component: {
+    id: string;
+    name: string;
+    type: string;
+    component_version: string | null;
+    image: string | null;
+  };
+  environment: { id: string; name: string };
+  edition: { id: string; name: string };
+  deploy: boolean;
+  gpu_list: string[];
+  replica: number;
+  gpu_memory_utilization: number | null;
+  extra_settings: Record<string, unknown>;
+  updated_at: string;
+}
+
+interface Pagination {
+  page: number;
+  per_page: number;
+  total: number;
+  total_pages: number;
+}
+
+interface SettingsTableProps {
+  data: SettingRow[];
+  pagination: Pagination;
+  isLoading?: boolean;
+  onPageChange: (page: number) => void;
+  onPerPageChange: (perPage: number) => void;
+  onSortingChange: (sortBy: string, sortOrder: "asc" | "desc") => void;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+}
+
+// Sub-components
+function DeployIndicator({ deploy }: { deploy: boolean }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={cn(
+          "inline-block h-2.5 w-2.5 rounded-full",
+          deploy
+            ? "bg-green-500 dark:bg-green-400"
+            : "bg-slate-300 dark:bg-slate-600"
+        )}
+        aria-hidden="true"
+      />
+      <span className="sr-only">{deploy ? "已部署" : "未部署"}</span>
+    </div>
+  );
+}
+
+function GpuMemBar({ value }: { value: number | null }) {
+  if (value === null) return <span className="text-xs text-slate-400">-</span>;
+  const percent = (value * 100).toFixed(0);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-16 rounded-full bg-slate-200 dark:bg-slate-700">
+        <div
+          className={cn(
+            "h-full rounded-full",
+            value >= 0.9
+              ? "bg-red-500"
+              : value >= 0.7
+                ? "bg-yellow-500"
+                : "bg-green-500"
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <span className="font-mono text-xs tabular-nums">{percent}%</span>
+    </div>
+  );
+}
+
+function GpuListTags({ gpuList }: { gpuList: string[] }) {
+  if (!gpuList || gpuList.length === 0) {
+    return <span className="text-xs text-slate-400">-</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {gpuList.map((gpu, i) => (
+        <Badge key={i} variant="secondary" className="font-mono text-xs">
+          {gpu}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+// Settings detail (expanded row)
+function SettingsDetail({ setting }: { setting: SettingRow }) {
+  const { model_component, extra_settings } = setting;
+  return (
+    <div className="grid grid-cols-2 gap-4 p-4 text-sm lg:grid-cols-4">
+      {model_component.image && (
+        <div>
+          <span className="text-xs font-medium text-slate-500">Image</span>
+          <p className="mt-1 break-all font-mono text-xs text-slate-700 dark:text-slate-300">
+            {model_component.image}
+          </p>
+        </div>
+      )}
+      {model_component.component_version && (
+        <div>
+          <span className="text-xs font-medium text-slate-500">
+            Component Version
+          </span>
+          <p className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-300">
+            {model_component.component_version}
+          </p>
+        </div>
+      )}
+      {extra_settings && Object.keys(extra_settings).length > 0 && (
+        <div className="col-span-2">
+          <span className="text-xs font-medium text-slate-500">
+            Extra Settings
+          </span>
+          <pre className="mt-1 overflow-auto rounded bg-slate-50 p-2 font-mono text-xs text-slate-700 dark:bg-slate-900 dark:text-slate-300">
+            {JSON.stringify(extra_settings, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Column definitions
+function createColumns(): ColumnDef<SettingRow>[] {
+  return [
+    {
+      id: "expander",
+      header: () => null,
+      cell: ({ row }) => (
+        <button
+          onClick={() => row.toggleExpanded()}
+          className="p-1 text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+          aria-label={row.getIsExpanded() ? "收合詳細資訊" : "展開詳細資訊"}
+        >
+          {row.getIsExpanded() ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRightIcon className="h-4 w-4" />
+          )}
+        </button>
+      ),
+      enableSorting: false,
+      size: 40,
+    },
+    {
+      accessorFn: (row) => row.model_component.name,
+      id: "name",
+      header: "Model Name",
+      cell: ({ row }) => (
+        <span className="font-mono font-medium">
+          {row.original.model_component.name}
+        </span>
+      ),
+    },
+    {
+      accessorFn: (row) => row.model_component.type,
+      id: "type",
+      header: "Type",
+      cell: ({ row }) => (
+        <ModelTypeBadge type={row.original.model_component.type} />
+      ),
+    },
+    {
+      accessorFn: (row) => row.environment.name,
+      id: "environment",
+      header: "Environment",
+      enableSorting: false,
+    },
+    {
+      accessorFn: (row) => row.edition.name,
+      id: "edition",
+      header: "Edition",
+      cell: ({ row }) => (
+        <Badge variant="outline" className="text-xs">
+          {row.original.edition.name}
+        </Badge>
+      ),
+      enableSorting: false,
+    },
+    {
+      accessorKey: "deploy",
+      header: "Deploy",
+      cell: ({ row }) => <DeployIndicator deploy={row.original.deploy} />,
+    },
+    {
+      accessorKey: "gpu_list",
+      header: "GPU List",
+      cell: ({ row }) => <GpuListTags gpuList={row.original.gpu_list} />,
+      enableSorting: false,
+    },
+    {
+      accessorKey: "replica",
+      header: "Replica",
+      cell: ({ row }) => (
+        <span className="font-mono tabular-nums">{row.original.replica}</span>
+      ),
+    },
+    {
+      accessorKey: "gpu_memory_utilization",
+      header: "GPU Mem Util",
+      cell: ({ row }) => (
+        <GpuMemBar value={row.original.gpu_memory_utilization} />
+      ),
+    },
+  ];
+}
+
+export function SettingsTable({
+  data,
+  pagination,
+  isLoading = false,
+  onPageChange,
+  onPerPageChange,
+  onSortingChange,
+  sortBy = "name",
+  sortOrder = "asc",
+}: SettingsTableProps) {
+  const columns = React.useMemo(() => createColumns(), []);
+  const [expanded, setExpanded] = React.useState<ExpandedState>({});
+
+  // Convert external sort state to TanStack sorting state
+  const sorting: SortingState = sortBy
+    ? [{ id: sortBy, desc: sortOrder === "desc" }]
+    : [];
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    manualSorting: true,
+    onSortingChange: (updater) => {
+      const newSorting =
+        typeof updater === "function" ? updater(sorting) : updater;
+      if (newSorting.length > 0) {
+        onSortingChange(newSorting[0].id, newSorting[0].desc ? "desc" : "asc");
+      } else {
+        onSortingChange("name", "asc");
+      }
+    },
+    onExpandedChange: setExpanded,
+    state: { sorting, expanded },
+    getRowCanExpand: () => true,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-slate-200 dark:border-slate-700">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    className={cn(
+                      "text-xs font-medium uppercase tracking-wide text-slate-500",
+                      header.column.getCanSort() &&
+                        "cursor-pointer select-none"
+                    )}
+                    onClick={header.column.getToggleSortingHandler()}
+                    style={{
+                      width:
+                        header.column.columnDef.size !== 150
+                          ? header.column.columnDef.size
+                          : undefined,
+                    }}
+                  >
+                    <div className="flex items-center gap-1">
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                      {header.column.getCanSort() && (
+                        <ArrowUpDown className="h-3.5 w-3.5" />
+                      )}
+                    </div>
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              // Skeleton loading rows
+              Array.from({ length: 8 }).map((_, i) => (
+                <TableRow key={`skeleton-${i}`}>
+                  {columns.map((_, j) => (
+                    <TableCell key={j} className="py-3">
+                      <div className="h-4 animate-pulse rounded bg-slate-100 dark:bg-slate-800" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row, index) => (
+                <React.Fragment key={row.id}>
+                  <TableRow
+                    className={cn(
+                      "hover:bg-slate-50 dark:hover:bg-slate-800/50",
+                      index % 2 === 1 &&
+                        "bg-slate-50/50 dark:bg-slate-800/25"
+                    )}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id} className="py-2 text-sm">
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                  {row.getIsExpanded() && (
+                    <TableRow>
+                      <TableCell colSpan={columns.length}>
+                        <div className="rounded-md bg-slate-50 dark:bg-slate-900/50">
+                          <SettingsDetail setting={row.original} />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </React.Fragment>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-sm text-slate-500"
+                >
+                  沒有符合條件的資料
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      {pagination && (
+        <div className="flex items-center justify-between px-2">
+          <p className="text-xs text-slate-500">
+            第{" "}
+            {pagination.total > 0
+              ? (pagination.page - 1) * pagination.per_page + 1
+              : 0}
+            -{Math.min(pagination.page * pagination.per_page, pagination.total)}{" "}
+            筆，共 {pagination.total} 筆
+          </p>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-slate-500">每頁</span>
+            <Select
+              value={String(pagination.per_page)}
+              onValueChange={(v) => onPerPageChange(Number(v))}
+            >
+              <SelectTrigger className="h-8 w-[70px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[20, 50, 100].map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              disabled={pagination.page <= 1}
+              onClick={() => onPageChange(pagination.page - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              <span className="sr-only">上一頁</span>
+            </Button>
+            <span className="text-sm tabular-nums">
+              {pagination.page} / {pagination.total_pages}
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              disabled={pagination.page >= pagination.total_pages}
+              onClick={() => onPageChange(pagination.page + 1)}
+            >
+              <ChevronRight className="h-4 w-4" />
+              <span className="sr-only">下一頁</span>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dev/src/components/sidebar.tsx
+++ b/dev/src/components/sidebar.tsx
@@ -1,28 +1,67 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { LayoutDashboard, Settings2, Table2 } from "lucide-react";
 
 const navItems = [
-  { name: "Dashboard", href: "/" },
-  { name: "Settings", href: "/settings" },
-  { name: "History", href: "/history" },
+  {
+    name: "版本清單",
+    href: "/",
+    icon: LayoutDashboard,
+    exact: true,
+  },
+  {
+    name: "Settings",
+    href: "/settings",
+    icon: Table2,
+    exact: false,
+  },
 ];
 
 export function Sidebar() {
+  const pathname = usePathname();
+
   return (
-    <aside className="flex w-64 flex-col border-r bg-white">
-      <div className="flex h-16 items-center border-b px-6">
-        <h1 className="text-lg font-bold text-gray-900">Sync Model GP</h1>
+    <aside className="flex h-screen w-64 flex-col border-r border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950">
+      {/* Brand */}
+      <div className="flex h-14 items-center gap-2 border-b border-slate-200 px-4 dark:border-slate-800">
+        <Settings2 className="h-5 w-5 text-blue-500" />
+        <span className="text-lg font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+          Sync Model
+        </span>
       </div>
-      <nav className="flex-1 space-y-1 p-4">
-        {navItems.map((item) => (
-          <Link
-            key={item.name}
-            href={item.href}
-            className="block rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-          >
-            {item.name}
-          </Link>
-        ))}
+
+      {/* Navigation */}
+      <nav className="flex-1 space-y-1 p-3">
+        {navItems.map((item) => {
+          const isActive = item.exact
+            ? pathname === item.href
+            : pathname.startsWith(item.href);
+
+          return (
+            <Link key={item.href} href={item.href}>
+              <div
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-50"
+                    : "text-slate-600 hover:bg-slate-50 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/50 dark:hover:text-slate-50"
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                <span>{item.name}</span>
+              </div>
+            </Link>
+          );
+        })}
       </nav>
+
+      {/* Footer */}
+      <div className="border-t border-slate-200 p-3 dark:border-slate-800">
+        <p className="text-[10px] text-slate-400">Sync Model v1.0</p>
+      </div>
     </aside>
   );
 }

--- a/dev/src/components/ui/badge.tsx
+++ b/dev/src/components/ui/badge.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "secondary" | "destructive" | "outline";
+}
+
+function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:focus:ring-slate-300",
+        {
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80":
+            variant === "default",
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80":
+            variant === "secondary",
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80":
+            variant === "destructive",
+          "text-slate-950 dark:text-slate-50": variant === "outline",
+        },
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Badge };

--- a/dev/src/components/ui/button.tsx
+++ b/dev/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link";
+  size?: "default" | "sm" | "lg" | "icon";
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", ...props }, ref) => {
+    return (
+      <button
+        className={cn(
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+          {
+            "bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90":
+              variant === "default",
+            "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90":
+              variant === "destructive",
+            "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50":
+              variant === "outline",
+            "bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80":
+              variant === "secondary",
+            "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50":
+              variant === "ghost",
+            "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50":
+              variant === "link",
+          },
+          {
+            "h-10 px-4 py-2": size === "default",
+            "h-9 rounded-md px-3": size === "sm",
+            "h-11 rounded-md px-8": size === "lg",
+            "h-10 w-10": size === "icon",
+          },
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button };

--- a/dev/src/components/ui/card.tsx
+++ b/dev/src/components/ui/card.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/dev/src/components/ui/input.tsx
+++ b/dev/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/dev/src/components/ui/select.tsx
+++ b/dev/src/components/ui/select.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { ChevronDown, Check } from "lucide-react";
+
+interface SelectContextType {
+  value: string;
+  onValueChange: (value: string) => void;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  disabled?: boolean;
+}
+
+const SelectContext = React.createContext<SelectContextType | null>(null);
+
+function useSelectContext() {
+  const context = React.useContext(SelectContext);
+  if (!context) throw new Error("Select components must be used within Select");
+  return context;
+}
+
+interface SelectProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+function Select({
+  value = "",
+  onValueChange = () => {},
+  disabled = false,
+  children,
+}: SelectProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <SelectContext.Provider
+      value={{ value, onValueChange, open, setOpen, disabled }}
+    >
+      <div className="relative">{children}</div>
+    </SelectContext.Provider>
+  );
+}
+
+interface SelectTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+const SelectTrigger = React.forwardRef<HTMLButtonElement, SelectTriggerProps>(
+  ({ className, children, ...props }, ref) => {
+    const { open, setOpen, disabled } = useSelectContext();
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="combobox"
+        aria-expanded={open}
+        disabled={disabled}
+        className={cn(
+          "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300",
+          className
+        )}
+        onClick={() => setOpen((prev) => !prev)}
+        {...props}
+      >
+        {children}
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </button>
+    );
+  }
+);
+SelectTrigger.displayName = "SelectTrigger";
+
+function SelectValue({ placeholder }: { placeholder?: string }) {
+  const { value } = useSelectContext();
+  return (
+    <span className={cn(!value && "text-slate-500")}>
+      {value || placeholder}
+    </span>
+  );
+}
+
+function SelectContent({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { open, setOpen } = useSelectContext();
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.parentElement?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [open, setOpen]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "absolute z-50 mt-1 max-h-60 min-w-[8rem] overflow-auto rounded-md border border-slate-200 bg-white p-1 shadow-md dark:border-slate-800 dark:bg-slate-950",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SelectItem({
+  value: itemValue,
+  children,
+  className,
+}: {
+  value: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const { value, onValueChange, setOpen } = useSelectContext();
+  const isSelected = value === itemValue;
+
+  return (
+    <div
+      role="option"
+      aria-selected={isSelected}
+      className={cn(
+        "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none hover:bg-slate-100 dark:hover:bg-slate-800",
+        isSelected && "bg-slate-100 dark:bg-slate-800",
+        className
+      )}
+      onClick={() => {
+        onValueChange(itemValue);
+        setOpen(false);
+      }}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        {isSelected && <Check className="h-4 w-4" />}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };

--- a/dev/src/components/ui/skeleton.tsx
+++ b/dev/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-slate-100 dark:bg-slate-800",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/dev/src/components/ui/switch.tsx
+++ b/dev/src/components/ui/switch.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SwitchProps {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ checked = false, onCheckedChange, disabled = false, className, id }, ref) => {
+    return (
+      <button
+        ref={ref}
+        id={id}
+        role="switch"
+        type="button"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onCheckedChange?.(!checked)}
+        className={cn(
+          "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50",
+          checked
+            ? "bg-slate-900 dark:bg-slate-50"
+            : "bg-slate-200 dark:bg-slate-800",
+          className
+        )}
+      >
+        <span
+          className={cn(
+            "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform dark:bg-slate-950",
+            checked ? "translate-x-5" : "translate-x-0"
+          )}
+        />
+      </button>
+    );
+  }
+);
+Switch.displayName = "Switch";
+
+export { Switch };

--- a/dev/src/components/ui/table.tsx
+++ b/dev/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-slate-100/50 font-medium dark:bg-slate-800/50 [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b border-slate-200 transition-colors hover:bg-slate-100/50 data-[state=selected]:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800/50 dark:data-[state=selected]:bg-slate-800",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-4 text-left align-middle font-medium text-slate-500 dark:text-slate-400 [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("px-4 py-2 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/dev/src/components/version-selector.tsx
+++ b/dev/src/components/version-selector.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Layers, Clock } from "lucide-react";
+
+interface Version {
+  id: string;
+  name: string;
+  description: string | null;
+  model_components_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface VersionCardProps {
+  version: Version;
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return "剛剛";
+  if (diffMins < 60) return `${diffMins} 分鐘前`;
+  if (diffHours < 24) return `${diffHours} 小時前`;
+  if (diffDays < 30) return `${diffDays} 天前`;
+  return date.toLocaleDateString("zh-TW");
+}
+
+function VersionCard({ version }: VersionCardProps) {
+  return (
+    <Link href={`/settings?version_id=${version.id}`}>
+      <Card className="cursor-pointer transition-all hover:border-blue-300 hover:shadow-md dark:hover:border-blue-700">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center justify-between">
+            <span className="text-xl font-bold">v{version.name}</span>
+            <Badge variant="secondary" className="font-mono text-xs">
+              <Layers className="mr-1 h-3 w-3" />
+              {version.model_components_count} models
+            </Badge>
+          </CardTitle>
+          {version.description && (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              {version.description}
+            </p>
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-1 text-xs text-slate-400">
+            <Clock className="h-3 w-3" />
+            <span>{formatTimeAgo(version.created_at)}</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+interface VersionSelectorProps {
+  versions: Version[];
+  isLoading?: boolean;
+}
+
+export function VersionSelector({
+  versions,
+  isLoading = false,
+}: VersionSelectorProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <Skeleton className="h-6 w-20" />
+              <Skeleton className="h-4 w-40" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-3 w-24" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (versions.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-lg border border-dashed border-slate-300 dark:border-slate-700">
+        <p className="text-sm text-slate-500">
+          目前沒有版本資料，請先匯入 cdk8s 設定
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {versions.map((version) => (
+        <VersionCard key={version.id} version={version} />
+      ))}
+    </div>
+  );
+}

--- a/dev/src/hooks/use-environments.ts
+++ b/dev/src/hooks/use-environments.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Environment {
+  id: string;
+  name: string;
+}
+
+interface UseEnvironmentsResult {
+  environments: Environment[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useEnvironments(versionId?: string): UseEnvironmentsResult {
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEnvironments = useCallback(async () => {
+    if (!versionId) {
+      setEnvironments([]);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/v1/versions/${versionId}/environments`
+      );
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const result = await res.json();
+      setEnvironments(result.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setEnvironments([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [versionId]);
+
+  useEffect(() => {
+    fetchEnvironments();
+  }, [fetchEnvironments]);
+
+  return { environments, isLoading, error };
+}

--- a/dev/src/hooks/use-settings.ts
+++ b/dev/src/hooks/use-settings.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { SettingRow } from "@/components/settings-table";
+
+interface Pagination {
+  page: number;
+  per_page: number;
+  total: number;
+  total_pages: number;
+}
+
+interface Filters {
+  available_types: string[];
+  available_environments: { id: string; name: string }[];
+  available_editions: { id: string; name: string }[];
+}
+
+interface SettingsResponse {
+  data: SettingRow[];
+  pagination: Pagination;
+  filters: Filters;
+}
+
+interface UseSettingsParams {
+  versionId: string;
+  environmentId?: string;
+  editionId?: string;
+  modelType?: string;
+  deployOnly?: boolean;
+  search?: string;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  page?: number;
+  perPage?: number;
+}
+
+interface UseSettingsResult {
+  data: SettingRow[];
+  pagination: Pagination | null;
+  filters: Filters | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useSettings(params: UseSettingsParams): UseSettingsResult {
+  const [data, setData] = useState<SettingRow[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [filters, setFilters] = useState<Filters | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSettings = useCallback(async () => {
+    if (!params.versionId) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    const searchParams = new URLSearchParams();
+    searchParams.set("version_id", params.versionId);
+    if (params.environmentId) searchParams.set("environment_id", params.environmentId);
+    if (params.editionId) searchParams.set("edition_id", params.editionId);
+    if (params.modelType) searchParams.set("model_type", params.modelType);
+    if (params.deployOnly) searchParams.set("deploy_only", "true");
+    if (params.search) searchParams.set("search", params.search);
+    if (params.sortBy) searchParams.set("sort_by", params.sortBy);
+    if (params.sortOrder) searchParams.set("sort_order", params.sortOrder);
+    if (params.page) searchParams.set("page", String(params.page));
+    if (params.perPage) searchParams.set("per_page", String(params.perPage));
+
+    try {
+      const res = await fetch(`/api/v1/settings?${searchParams.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || `HTTP ${res.status}`);
+      }
+      const result: SettingsResponse = await res.json();
+      setData(result.data);
+      setPagination(result.pagination);
+      setFilters(result.filters);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setData([]);
+      setPagination(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    params.versionId,
+    params.environmentId,
+    params.editionId,
+    params.modelType,
+    params.deployOnly,
+    params.search,
+    params.sortBy,
+    params.sortOrder,
+    params.page,
+    params.perPage,
+  ]);
+
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
+  return { data, pagination, filters, isLoading, error, refetch: fetchSettings };
+}

--- a/dev/src/hooks/use-versions.ts
+++ b/dev/src/hooks/use-versions.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Version {
+  id: string;
+  name: string;
+  description: string | null;
+  model_components_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Pagination {
+  page: number;
+  per_page: number;
+  total: number;
+  total_pages: number;
+}
+
+interface UseVersionsResult {
+  versions: Version[];
+  pagination: Pagination | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useVersions(
+  page: number = 1,
+  perPage: number = 20
+): UseVersionsResult {
+  const [versions, setVersions] = useState<Version[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchVersions = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/v1/versions?page=${page}&per_page=${perPage}`
+      );
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const result = await res.json();
+      setVersions(result.data);
+      setPagination(result.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setVersions([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, perPage]);
+
+  useEffect(() => {
+    fetchVersions();
+  }, [fetchVersions]);
+
+  return { versions, pagination, isLoading, error };
+}

--- a/dev/src/lib/queries/settings.ts
+++ b/dev/src/lib/queries/settings.ts
@@ -1,0 +1,273 @@
+import { db } from "@/db";
+import {
+  modelSettings,
+  modelComponents,
+  environments,
+  editions,
+} from "@/db/schema";
+import { eq, and, ilike, sql, asc, desc } from "drizzle-orm";
+
+export interface SettingsQueryParams {
+  versionId: string;
+  environmentId?: string;
+  editionId?: string;
+  modelType?: string;
+  deployOnly?: boolean;
+  search?: string;
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+  page: number;
+  perPage: number;
+}
+
+export async function querySettings(params: SettingsQueryParams) {
+  const {
+    versionId,
+    environmentId,
+    editionId,
+    modelType,
+    deployOnly,
+    search,
+    sortBy,
+    sortOrder,
+    page,
+    perPage,
+  } = params;
+
+  const conditions = [eq(modelComponents.versionId, versionId)];
+
+  if (environmentId) {
+    conditions.push(eq(modelSettings.environmentId, environmentId));
+  }
+  if (editionId) {
+    conditions.push(eq(modelSettings.editionId, editionId));
+  }
+  if (modelType) {
+    conditions.push(eq(modelComponents.type, modelType));
+  }
+  if (deployOnly) {
+    conditions.push(eq(modelSettings.deploy, true));
+  }
+  if (search) {
+    conditions.push(ilike(modelComponents.name, `%${search}%`));
+  }
+
+  const whereClause = and(...conditions);
+
+  // Determine sort column
+  const sortColumn = (() => {
+    switch (sortBy) {
+      case "name":
+        return modelComponents.name;
+      case "type":
+        return modelComponents.type;
+      case "deploy":
+        return modelSettings.deploy;
+      case "replica":
+        return modelSettings.replica;
+      case "gpu_memory_utilization":
+        return modelSettings.gpuMemoryUtilization;
+      default:
+        return modelComponents.name;
+    }
+  })();
+
+  const orderFn = sortOrder === "desc" ? desc : asc;
+
+  const [data, countResult] = await Promise.all([
+    db
+      .select({
+        id: modelSettings.id,
+        modelComponentId: modelComponents.id,
+        modelComponentName: modelComponents.name,
+        modelComponentType: modelComponents.type,
+        componentVersion: modelComponents.componentVersion,
+        image: modelComponents.image,
+        environmentId: environments.id,
+        environmentName: environments.name,
+        editionId: editions.id,
+        editionName: editions.name,
+        deploy: modelSettings.deploy,
+        gpuList: modelSettings.gpuList,
+        replica: modelSettings.replica,
+        gpuMemoryUtilization: modelSettings.gpuMemoryUtilization,
+        extraSettings: modelSettings.extraSettings,
+        updatedAt: modelSettings.updatedAt,
+      })
+      .from(modelSettings)
+      .innerJoin(
+        modelComponents,
+        eq(modelSettings.modelComponentId, modelComponents.id)
+      )
+      .innerJoin(
+        environments,
+        eq(modelSettings.environmentId, environments.id)
+      )
+      .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+      .where(whereClause)
+      .orderBy(orderFn(sortColumn))
+      .limit(perPage)
+      .offset((page - 1) * perPage),
+
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(modelSettings)
+      .innerJoin(
+        modelComponents,
+        eq(modelSettings.modelComponentId, modelComponents.id)
+      )
+      .innerJoin(
+        environments,
+        eq(modelSettings.environmentId, environments.id)
+      )
+      .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+      .where(whereClause),
+  ]);
+
+  // Get available filter options for this version
+  const [availableTypes, availableEnvironments, availableEditions] =
+    await Promise.all([
+      db
+        .selectDistinct({ type: modelComponents.type })
+        .from(modelComponents)
+        .where(eq(modelComponents.versionId, versionId))
+        .then((rows) => rows.map((r) => r.type)),
+
+      db
+        .selectDistinct({
+          id: environments.id,
+          name: environments.name,
+        })
+        .from(environments)
+        .innerJoin(
+          modelSettings,
+          eq(modelSettings.environmentId, environments.id)
+        )
+        .innerJoin(
+          modelComponents,
+          eq(modelSettings.modelComponentId, modelComponents.id)
+        )
+        .where(eq(modelComponents.versionId, versionId)),
+
+      db
+        .selectDistinct({
+          id: editions.id,
+          name: editions.name,
+        })
+        .from(editions)
+        .innerJoin(
+          modelSettings,
+          eq(modelSettings.editionId, editions.id)
+        )
+        .innerJoin(
+          modelComponents,
+          eq(modelSettings.modelComponentId, modelComponents.id)
+        )
+        .where(eq(modelComponents.versionId, versionId)),
+    ]);
+
+  const total = countResult[0]?.count ?? 0;
+
+  return {
+    data: data.map((row) => ({
+      id: row.id,
+      model_component: {
+        id: row.modelComponentId,
+        name: row.modelComponentName,
+        type: row.modelComponentType,
+        component_version: row.componentVersion,
+        image: row.image,
+      },
+      environment: {
+        id: row.environmentId,
+        name: row.environmentName,
+      },
+      edition: {
+        id: row.editionId,
+        name: row.editionName,
+      },
+      deploy: row.deploy,
+      gpu_list: row.gpuList ?? [],
+      replica: row.replica,
+      gpu_memory_utilization: row.gpuMemoryUtilization
+        ? parseFloat(row.gpuMemoryUtilization)
+        : null,
+      extra_settings: row.extraSettings ?? {},
+      updated_at: row.updatedAt.toISOString(),
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total,
+      total_pages: Math.ceil(total / perPage) || 1,
+    },
+    filters: {
+      available_types: availableTypes,
+      available_environments: availableEnvironments,
+      available_editions: availableEditions,
+    },
+  };
+}
+
+export async function getSettingById(settingId: string) {
+  const result = await db
+    .select({
+      id: modelSettings.id,
+      modelComponentId: modelComponents.id,
+      modelComponentName: modelComponents.name,
+      modelComponentType: modelComponents.type,
+      componentVersion: modelComponents.componentVersion,
+      image: modelComponents.image,
+      environmentId: environments.id,
+      environmentName: environments.name,
+      editionId: editions.id,
+      editionName: editions.name,
+      deploy: modelSettings.deploy,
+      gpuList: modelSettings.gpuList,
+      replica: modelSettings.replica,
+      gpuMemoryUtilization: modelSettings.gpuMemoryUtilization,
+      extraSettings: modelSettings.extraSettings,
+      createdAt: modelSettings.createdAt,
+      updatedAt: modelSettings.updatedAt,
+    })
+    .from(modelSettings)
+    .innerJoin(
+      modelComponents,
+      eq(modelSettings.modelComponentId, modelComponents.id)
+    )
+    .innerJoin(environments, eq(modelSettings.environmentId, environments.id))
+    .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+    .where(eq(modelSettings.id, settingId))
+    .limit(1);
+
+  if (result.length === 0) return null;
+
+  const row = result[0];
+  return {
+    id: row.id,
+    model_component: {
+      id: row.modelComponentId,
+      name: row.modelComponentName,
+      type: row.modelComponentType,
+      component_version: row.componentVersion,
+      image: row.image,
+    },
+    environment: {
+      id: row.environmentId,
+      name: row.environmentName,
+    },
+    edition: {
+      id: row.editionId,
+      name: row.editionName,
+    },
+    deploy: row.deploy,
+    gpu_list: row.gpuList ?? [],
+    replica: row.replica,
+    gpu_memory_utilization: row.gpuMemoryUtilization
+      ? parseFloat(row.gpuMemoryUtilization)
+      : null,
+    extra_settings: row.extraSettings ?? {},
+    created_at: row.createdAt.toISOString(),
+    updated_at: row.updatedAt.toISOString(),
+  };
+}

--- a/dev/src/lib/queries/versions.ts
+++ b/dev/src/lib/queries/versions.ts
@@ -1,0 +1,132 @@
+import { db } from "@/db";
+import { versions, modelComponents, environments, editions, modelSettings } from "@/db/schema";
+import { eq, sql, desc } from "drizzle-orm";
+
+export interface VersionsQueryParams {
+  page: number;
+  perPage: number;
+}
+
+export async function queryVersions(params: VersionsQueryParams) {
+  const { page, perPage } = params;
+  const offset = (page - 1) * perPage;
+
+  const [data, countResult] = await Promise.all([
+    db
+      .select({
+        id: versions.id,
+        name: versions.name,
+        description: versions.description,
+        createdAt: versions.createdAt,
+        updatedAt: versions.updatedAt,
+      })
+      .from(versions)
+      .orderBy(desc(versions.createdAt))
+      .limit(perPage)
+      .offset(offset),
+
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(versions),
+  ]);
+
+  // Get model component counts for each version
+  const versionIds = data.map((v) => v.id);
+  const componentCounts =
+    versionIds.length > 0
+      ? await db
+          .select({
+            versionId: modelComponents.versionId,
+            count: sql<number>`count(*)::int`.as("count"),
+          })
+          .from(modelComponents)
+          .where(
+            sql`${modelComponents.versionId} IN (${sql.join(
+              versionIds.map((id) => sql`${id}`),
+              sql`, `
+            )})`
+          )
+          .groupBy(modelComponents.versionId)
+      : [];
+
+  const countMap = new Map(componentCounts.map((c) => [c.versionId, c.count]));
+
+  const total = countResult[0]?.count ?? 0;
+
+  return {
+    data: data.map((v) => ({
+      id: v.id,
+      name: v.name,
+      description: v.description,
+      model_components_count: countMap.get(v.id) ?? 0,
+      created_at: v.createdAt.toISOString(),
+      updated_at: v.updatedAt.toISOString(),
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total,
+      total_pages: Math.ceil(total / perPage) || 1,
+    },
+  };
+}
+
+export async function getVersionById(versionId: string) {
+  const result = await db
+    .select()
+    .from(versions)
+    .where(eq(versions.id, versionId))
+    .limit(1);
+
+  if (result.length === 0) return null;
+
+  const componentCount = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(modelComponents)
+    .where(eq(modelComponents.versionId, versionId));
+
+  return {
+    id: result[0].id,
+    name: result[0].name,
+    description: result[0].description,
+    model_components_count: componentCount[0]?.count ?? 0,
+    created_at: result[0].createdAt.toISOString(),
+    updated_at: result[0].updatedAt.toISOString(),
+  };
+}
+
+export async function getEnvironmentsByVersionId(versionId: string) {
+  // Get distinct environments that have settings for this version
+  const result = await db
+    .selectDistinct({
+      id: environments.id,
+      name: environments.name,
+    })
+    .from(environments)
+    .innerJoin(modelSettings, eq(modelSettings.environmentId, environments.id))
+    .innerJoin(
+      modelComponents,
+      eq(modelSettings.modelComponentId, modelComponents.id)
+    )
+    .where(eq(modelComponents.versionId, versionId));
+
+  return { data: result };
+}
+
+export async function getEditionsByVersionId(versionId: string) {
+  // Get distinct editions that have settings for this version
+  const result = await db
+    .selectDistinct({
+      id: editions.id,
+      name: editions.name,
+    })
+    .from(editions)
+    .innerJoin(modelSettings, eq(modelSettings.editionId, editions.id))
+    .innerJoin(
+      modelComponents,
+      eq(modelSettings.modelComponentId, modelComponents.id)
+    )
+    .where(eq(modelComponents.versionId, versionId));
+
+  return { data: result };
+}

--- a/dev/src/lib/utils.ts
+++ b/dev/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- GET /api/v1/settings with version/env/edition/modelType filters and pagination
- GET /api/v1/versions with pagination and model component counts
- GET /api/v1/versions/:id/environments and /editions endpoints
- Settings page with version selector, environment tabs, edition filter, model type filter
- TanStack Table with server-side sort, pagination, and expandable detail rows
- Model type badges with semantic colors per design tokens
- URL search params state sync for shareable/bookmarkable filters
- Data fetching hooks (use-settings, use-versions, use-environments)
- shadcn/ui base components (Table, Badge, Button, Card, Select, Input, Switch, Skeleton)

Closes #8

## Test plan
- [ ] Verify GET /api/v1/versions returns paginated version list
- [ ] Verify GET /api/v1/settings?version_id=... returns filtered settings
- [ ] Verify 400 error when version_id is missing
- [ ] Verify 404 error when version_id does not exist
- [ ] Verify environment/edition/modelType/deployOnly filters work
- [ ] Verify search with debounce works
- [ ] Verify sort by column headers
- [ ] Verify pagination controls
- [ ] Verify expandable rows show detail info
- [ ] Verify URL params sync (shareable links)