### PR TITLE
fix: Sprint 1 驗證問題修復

### DIFF
--- a/dev/src/app/api/v1/import/cdk8s/route.ts
+++ b/dev/src/app/api/v1/import/cdk8s/route.ts
@@ -10,7 +10,7 @@
  *   { status, version?, summary, warnings }
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
@@ -27,7 +27,10 @@ import type {
   ImportSummary,
   ParsedEditionGpuSettings,
   ParsedModelComponent,
+  ParsedEnvironment,
 } from "@/lib/cdk8s-parser/types";
+import { successResponse, errorResponse } from "@/lib/api";
+import { ApiError, ErrorCodes } from "@/lib/api-error";
 
 const requestSchema = z.object({
   repoPath: z.string().min(1, "repoPath 不可為空"),
@@ -39,70 +42,64 @@ const requestSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
-  // 1. 驗證輸入
-  let body: z.infer<typeof requestSchema>;
   try {
-    const raw = await request.json();
-    body = requestSchema.parse(raw);
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: "INVALID_INPUT", details: err.errors },
-        { status: 400 }
+    // 1. 驗證輸入
+    let body: z.infer<typeof requestSchema>;
+    try {
+      const raw = await request.json();
+      body = requestSchema.parse(raw);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new ApiError("INVALID_INPUT", "輸入驗證失敗", err.errors);
+      }
+      throw new ApiError("INVALID_INPUT", "無效的 JSON");
+    }
+
+    const { repoPath, versionName, dryRun } = body;
+
+    // 2. 檢查 version 是否已存在
+    if (!dryRun) {
+      const existing = await db
+        .select()
+        .from(versions)
+        .where(eq(versions.name, versionName))
+        .limit(1);
+      if (existing.length > 0) {
+        throw new ApiError(
+          "DUPLICATE",
+          `版本 "${versionName}" 已存在`
+        );
+      }
+    }
+
+    // 3. 解析 cdk8s repo
+    let parseResult;
+    try {
+      parseResult = await parseCdk8sRepo(repoPath);
+    } catch (err) {
+      throw new ApiError(
+        "PARSE_ERROR",
+        err instanceof Error ? err.message : "設定檔解析失敗"
       );
     }
-    return NextResponse.json(
-      { error: "INVALID_INPUT", message: "無效的 JSON" },
-      { status: 400 }
+
+    // 4. 計算 summary
+    const summary = buildSummary(
+      parseResult.editions,
+      parseResult.modelComponents,
+      parseResult.environments
     );
-  }
 
-  const { repoPath, versionName, dryRun } = body;
-
-  // 2. 檢查 version 是否已存在
-  if (!dryRun) {
-    const existing = await db
-      .select()
-      .from(versions)
-      .where(eq(versions.name, versionName))
-      .limit(1);
-    if (existing.length > 0) {
-      return NextResponse.json(
-        { error: "DUPLICATE", message: `版本 "${versionName}" 已存在` },
-        { status: 409 }
-      );
+    // 5. Dry run — 只回傳解析結果
+    if (dryRun) {
+      return successResponse({
+        status: "dry_run",
+        summary,
+        warnings: parseResult.warnings,
+      } satisfies ImportResponse);
     }
-  }
 
-  // 3. 解析 cdk8s repo
-  let parseResult;
-  try {
-    parseResult = await parseCdk8sRepo(repoPath);
-  } catch (err) {
-    return NextResponse.json(
-      {
-        error: "PARSE_ERROR",
-        message:
-          err instanceof Error ? err.message : "設定檔解析失敗",
-      },
-      { status: 422 }
-    );
-  }
-
-  // 4. 計算 summary
-  const summary = buildSummary(parseResult.editions, parseResult.modelComponents);
-
-  // 5. Dry run — 只回傳解析結果
-  if (dryRun) {
-    return NextResponse.json({
-      status: "dry_run",
-      summary,
-      warnings: parseResult.warnings,
-    } satisfies ImportResponse);
-  }
-
-  // 6. 寫入資料庫
-  try {
+    // 6. 寫入資料庫
     const versionRecord = await writeToDatabase(
       versionName,
       parseResult.editions,
@@ -110,7 +107,7 @@ export async function POST(request: NextRequest) {
       summary
     );
 
-    return NextResponse.json({
+    return successResponse({
       status: "success",
       version: {
         id: versionRecord.id,
@@ -120,13 +117,14 @@ export async function POST(request: NextRequest) {
       warnings: parseResult.warnings,
     } satisfies ImportResponse);
   } catch (err) {
-    return NextResponse.json(
-      {
-        error: "DB_ERROR",
-        message:
-          err instanceof Error ? err.message : "資料庫寫入失敗",
-      },
-      { status: 500 }
+    if (err instanceof ApiError) {
+      return errorResponse(err.code, err.message, err.status, err.details);
+    }
+    console.error("Import failed:", err);
+    return errorResponse(
+      ErrorCodes.INTERNAL_ERROR.code,
+      err instanceof Error ? err.message : "資料庫寫入失敗",
+      ErrorCodes.INTERNAL_ERROR.status
     );
   }
 }
@@ -136,9 +134,11 @@ export async function POST(request: NextRequest) {
  */
 function buildSummary(
   editionsList: ParsedEditionGpuSettings[],
-  componentsList: ParsedModelComponent[]
+  componentsList: ParsedModelComponent[],
+  environmentsList: ParsedEnvironment[]
 ): ImportSummary {
   const editionNames = editionsList.map((e) => e.editionName);
+  const environmentNames = environmentsList.map((e) => e.name);
 
   // 計算 model types 分佈
   const modelTypes: Record<string, number> = {};
@@ -150,10 +150,11 @@ function buildSummary(
   const modelSettingsCount = componentsList.length * editionsList.length;
 
   return {
-    environmentsCount: 0, // 環境數（本版不從 cfg 寫入，設為 0）
+    environmentsCount: environmentNames.length,
     editionsCount: editionNames.length,
     modelComponentsCount: componentsList.length,
     modelSettingsCount,
+    environments: environmentNames,
     editions: editionNames,
     modelTypes,
   };

--- a/dev/src/app/api/v1/import/cdk8s/status/[importId]/route.ts
+++ b/dev/src/app/api/v1/import/cdk8s/status/[importId]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * GET /api/v1/import/cdk8s/status/:importId
+ *
+ * 查詢匯入作業的狀態。
+ */
+
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { imports } from "@/db/schema";
+import { successResponse, errorResponse } from "@/lib/api";
+import { ErrorCodes } from "@/lib/api-error";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ importId: string }> }
+) {
+  try {
+    const { importId } = await params;
+
+    const result = await db
+      .select()
+      .from(imports)
+      .where(eq(imports.id, importId))
+      .limit(1);
+
+    if (result.length === 0) {
+      return errorResponse(
+        ErrorCodes.NOT_FOUND.code,
+        "Import record not found",
+        ErrorCodes.NOT_FOUND.status
+      );
+    }
+
+    const record = result[0];
+
+    return successResponse({
+      id: record.id,
+      status: record.status,
+      progress: record.progress,
+      summary: record.summary,
+      started_at: record.startedAt.toISOString(),
+      completed_at: record.completedAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    console.error("Failed to fetch import status:", error);
+    return errorResponse(
+      ErrorCodes.INTERNAL_ERROR.code,
+      "Failed to fetch import status",
+      ErrorCodes.INTERNAL_ERROR.status
+    );
+  }
+}

--- a/dev/src/db/schema/import.ts
+++ b/dev/src/db/schema/import.ts
@@ -1,0 +1,19 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  integer,
+  jsonb,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { versions } from "./version";
+
+export const imports = pgTable("imports", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  versionId: uuid("version_id").references(() => versions.id),
+  status: varchar("status", { length: 20 }).notNull().default("pending"),
+  progress: integer("progress").notNull().default(0),
+  summary: jsonb("summary"),
+  startedAt: timestamp("started_at").defaultNow().notNull(),
+  completedAt: timestamp("completed_at"),
+});

--- a/dev/src/db/schema/index.ts
+++ b/dev/src/db/schema/index.ts
@@ -5,3 +5,4 @@ export { modelComponents } from "./model-component";
 export { modelSettings } from "./model-setting";
 export { changeHistories } from "./change-history";
 export { mergeRequests } from "./merge-request";
+export { imports } from "./import";

--- a/dev/src/lib/api-error.ts
+++ b/dev/src/lib/api-error.ts
@@ -2,7 +2,9 @@ export const ErrorCodes = {
   INVALID_INPUT: { code: "INVALID_INPUT", status: 400 },
   NOT_FOUND: { code: "NOT_FOUND", status: 404 },
   DUPLICATE: { code: "DUPLICATE", status: 409 },
+  PARSE_ERROR: { code: "PARSE_ERROR", status: 422 },
   INTERNAL_ERROR: { code: "INTERNAL_ERROR", status: 500 },
+  GITLAB_ERROR: { code: "GITLAB_ERROR", status: 502 },
   DB_CONNECTION_ERROR: { code: "DB_CONNECTION_ERROR", status: 503 },
 } as const;
 

--- a/dev/src/lib/cdk8s-parser/types.ts
+++ b/dev/src/lib/cdk8s-parser/types.ts
@@ -81,6 +81,7 @@ export interface ImportSummary {
   editionsCount: number;
   modelComponentsCount: number;
   modelSettingsCount: number;
+  environments: string[];
   editions: string[];
   modelTypes: Record<string, number>;
 }


### PR DESCRIPTION
## Summary
修復 Sprint 1 三維度驗證報告中的問題：

- 統一所有 API error response 格式為 `{code, message}`
- 新增缺少的 ErrorCodes（PARSE_ERROR, GITLAB_ERROR）
- Route handlers 統一使用 ApiError class
- Import API response 加入 environments 計數
- 新增 Import Status API endpoint

## Verification Report
See `specs/verify-sprint-1.md`