### PR TITLE
feat: F-004 設定編輯 + F-006 版本比較

### DIFF
--- a/dev/src/app/api/v1/compare/route.ts
+++ b/dev/src/app/api/v1/compare/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { successResponse, errorResponse } from "@/lib/api";
+import { compareVersions, CompareError } from "@/lib/queries/compare";
+
+const compareQuerySchema = z
+  .object({
+    version_a_id: z.string().uuid("version_a_id must be a valid UUID"),
+    version_b_id: z.string().uuid("version_b_id must be a valid UUID"),
+    environment_id: z.string().uuid().optional(),
+    edition_id: z.string().uuid().optional(),
+  })
+  .refine((data) => data.version_a_id !== data.version_b_id, {
+    message: "Cannot compare a version with itself",
+    path: ["version_b_id"],
+  });
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = Object.fromEntries(
+      request.nextUrl.searchParams.entries()
+    );
+
+    if (!searchParams.version_a_id || !searchParams.version_b_id) {
+      return errorResponse(
+        "INVALID_INPUT",
+        "version_a_id and version_b_id are required",
+        400
+      );
+    }
+
+    const parseResult = compareQuerySchema.safeParse(searchParams);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors.map((e) => e.message).join(", "),
+        400
+      );
+    }
+
+    const query = parseResult.data;
+
+    const result = await compareVersions({
+      versionAId: query.version_a_id,
+      versionBId: query.version_b_id,
+      environmentId: query.environment_id,
+      editionId: query.edition_id,
+    });
+
+    return successResponse(result);
+  } catch (error) {
+    if (error instanceof CompareError) {
+      return errorResponse(error.code, error.message, error.status);
+    }
+    console.error("Failed to compare versions:", error);
+    return errorResponse(
+      "INTERNAL_ERROR",
+      "Failed to compare versions",
+      500
+    );
+  }
+}

--- a/dev/src/app/api/v1/settings/[settingId]/route.ts
+++ b/dev/src/app/api/v1/settings/[settingId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { successResponse, errorResponse } from "@/lib/api";
-import { getSettingById } from "@/lib/queries/settings";
+import { getSettingById, updateSetting, UpdateSettingError } from "@/lib/queries/settings";
 
 export async function GET(
   _request: NextRequest,
@@ -18,5 +19,80 @@ export async function GET(
   } catch (error) {
     console.error("Failed to fetch setting:", error);
     return errorResponse("INTERNAL_ERROR", "Failed to fetch setting", 500);
+  }
+}
+
+const patchSettingSchema = z.object({
+  deploy: z.boolean().optional(),
+  gpu_list: z.array(z.string().max(50)).optional(),
+  replica: z.number().int().min(0).optional(),
+  gpu_memory_utilization: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .transform((v) =>
+      v !== undefined ? Math.round(v * 100) / 100 : undefined
+    ),
+  extra_settings: z.record(z.unknown()).optional(),
+  reason: z.string().max(500).optional(),
+  changed_by: z.string().max(100),
+  expected_updated_at: z.string().optional(),
+});
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ settingId: string }> }
+) {
+  try {
+    const { settingId } = await params;
+    const body = await request.json();
+
+    const parseResult = patchSettingSchema.safeParse(body);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", "),
+        400
+      );
+    }
+
+    const { changed_by, reason, expected_updated_at, ...changes } =
+      parseResult.data;
+
+    // Filter out undefined values
+    const cleanChanges: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(changes)) {
+      if (value !== undefined) {
+        cleanChanges[key] = value;
+      }
+    }
+
+    if (Object.keys(cleanChanges).length === 0) {
+      return errorResponse(
+        "INVALID_INPUT",
+        "At least one setting field must be provided",
+        400
+      );
+    }
+
+    const result = await updateSetting(
+      settingId,
+      cleanChanges,
+      changed_by,
+      reason,
+      expected_updated_at
+    );
+
+    return successResponse({
+      ...result.setting,
+      change_history_id: result.changeHistoryId,
+    });
+  } catch (error) {
+    if (error instanceof UpdateSettingError) {
+      return errorResponse(error.code, error.message, error.status);
+    }
+    console.error("Failed to update setting:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to update setting", 500);
   }
 }

--- a/dev/src/app/compare/page.tsx
+++ b/dev/src/app/compare/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { VersionCompare } from "@/components/version-compare";
+import { SideBySideDiff } from "@/components/side-by-side-diff";
+
+interface CompareResult {
+  version_a: { id: string; name: string };
+  version_b: { id: string; name: string };
+  summary: {
+    added: number;
+    removed: number;
+    modified: number;
+    unchanged: number;
+  };
+  changes: Array<{
+    model_component_name: string;
+    model_type: string;
+    environment: string;
+    edition: string;
+    change_type: "added" | "removed" | "modified";
+    diff: Record<string, { version_a: unknown; version_b: unknown }>;
+  }>;
+}
+
+export default function ComparePage() {
+  const [result, setResult] = useState<CompareResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCompare = useCallback(
+    async (params: {
+      versionAId: string;
+      versionBId: string;
+      environmentId?: string;
+      editionId?: string;
+    }) => {
+      setIsLoading(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        const searchParams = new URLSearchParams();
+        searchParams.set("version_a_id", params.versionAId);
+        searchParams.set("version_b_id", params.versionBId);
+        if (params.environmentId)
+          searchParams.set("environment_id", params.environmentId);
+        if (params.editionId)
+          searchParams.set("edition_id", params.editionId);
+
+        const res = await fetch(
+          `/api/v1/compare?${searchParams.toString()}`
+        );
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.message || `HTTP ${res.status}`);
+        }
+
+        const data: CompareResult = await res.json();
+        setResult(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "比較失敗");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  return (
+    <div className="mx-auto max-w-[1400px] space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+          版本比較
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          選擇兩個版本，比較 model 設定的差異
+        </p>
+      </div>
+
+      {/* Version selector */}
+      <VersionCompare onCompare={handleCompare} isLoading={isLoading} />
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex h-32 items-center justify-center text-sm text-slate-500">
+          載入比較結果中...
+        </div>
+      )}
+
+      {/* Results */}
+      {result && !isLoading && <SideBySideDiff result={result} />}
+    </div>
+  );
+}

--- a/dev/src/app/settings/page.tsx
+++ b/dev/src/app/settings/page.tsx
@@ -19,6 +19,15 @@ import {
 } from "@/components/ui/select";
 import { Search, X, ArrowLeft } from "lucide-react";
 import Link from "next/link";
+import { EditSettingsForm, type EditChanges } from "@/components/edit-settings-form";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { SettingRow } from "@/components/settings-table";
 
 const ALL_MODEL_TYPES = [
   "LLM",
@@ -48,6 +57,12 @@ export default function SettingsPage() {
   const sortOrder = (searchParams.get("sort_order") ?? "asc") as "asc" | "desc";
   const page = parseInt(searchParams.get("page") ?? "1", 10);
   const perPage = parseInt(searchParams.get("per_page") ?? "50", 10);
+
+  // Edit state
+  const [editingSetting, setEditingSetting] = useState<SettingRow | null>(null);
+  const [pendingChanges, setPendingChanges] = useState<EditChanges | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   // Local search input state (for debounce)
   const [searchInput, setSearchInput] = useState(search);
@@ -120,6 +135,56 @@ export default function SettingsPage() {
     !!modelType ||
     deployOnly ||
     !!search;
+
+  // Edit handlers
+  const handleEditSetting = useCallback((setting: SettingRow) => {
+    setEditingSetting(setting);
+    setPendingChanges(null);
+    setShowConfirm(false);
+  }, []);
+
+  const handleEditSave = useCallback((changes: EditChanges) => {
+    setPendingChanges(changes);
+    setShowConfirm(true);
+  }, []);
+
+  const handleConfirmSave = useCallback(async () => {
+    if (!editingSetting || !pendingChanges) return;
+    setIsSaving(true);
+
+    try {
+      const { changed_by, reason, expected_updated_at, ...settingChanges } = pendingChanges;
+      const res = await fetch(`/api/v1/settings/${editingSetting.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...settingChanges,
+          changed_by,
+          reason,
+          expected_updated_at,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || `HTTP ${res.status}`);
+      }
+
+      // Success - close dialogs and refresh
+      setShowConfirm(false);
+      setEditingSetting(null);
+      setPendingChanges(null);
+      // Trigger refetch
+      if (data) {
+        // Refresh by re-navigating to current URL
+        router.push(`/settings?${searchParams.toString()}`, { scroll: false });
+      }
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "儲存失敗");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editingSetting, pendingChanges, data, router, searchParams]);
 
   // No version selected state
   if (!versionId) {
@@ -287,7 +352,44 @@ export default function SettingsPage() {
         }
         sortBy={sortBy}
         sortOrder={sortOrder}
+        onEditSetting={handleEditSetting}
       />
+
+      {/* Edit Setting Dialog */}
+      <Dialog
+        open={!!editingSetting && !showConfirm}
+        onOpenChange={(open) => {
+          if (!open) setEditingSetting(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>編輯設定</DialogTitle>
+          </DialogHeader>
+          {editingSetting && (
+            <EditSettingsForm
+              setting={editingSetting}
+              onSave={handleEditSave}
+              onCancel={() => setEditingSetting(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirm Dialog */}
+      {editingSetting && (
+        <ConfirmDialog
+          open={showConfirm}
+          onOpenChange={(open) => {
+            setShowConfirm(open);
+            if (!open) setPendingChanges(null);
+          }}
+          setting={editingSetting}
+          changes={pendingChanges}
+          onConfirm={handleConfirmSave}
+          isSubmitting={isSaving}
+        />
+      )}
     </div>
   );
 }

--- a/dev/src/components/confirm-dialog.tsx
+++ b/dev/src/components/confirm-dialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { SettingRow } from "@/components/settings-table";
+import type { EditChanges } from "@/components/edit-settings-form";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  setting: SettingRow;
+  changes: EditChanges | null;
+  onConfirm: () => void;
+  isSubmitting?: boolean;
+}
+
+interface DiffItem {
+  field: string;
+  label: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "(empty)";
+  if (typeof value === "number") return String(value);
+  return String(value);
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  setting,
+  changes,
+  onConfirm,
+  isSubmitting = false,
+}: ConfirmDialogProps) {
+  if (!changes) return null;
+
+  const diffItems: DiffItem[] = [];
+
+  if (changes.deploy !== undefined) {
+    diffItems.push({
+      field: "deploy",
+      label: "Deploy",
+      oldValue: setting.deploy,
+      newValue: changes.deploy,
+    });
+  }
+  if (changes.gpu_list !== undefined) {
+    diffItems.push({
+      field: "gpu_list",
+      label: "GPU List",
+      oldValue: setting.gpu_list,
+      newValue: changes.gpu_list,
+    });
+  }
+  if (changes.replica !== undefined) {
+    diffItems.push({
+      field: "replica",
+      label: "Replica",
+      oldValue: setting.replica,
+      newValue: changes.replica,
+    });
+  }
+  if (changes.gpu_memory_utilization !== undefined) {
+    diffItems.push({
+      field: "gpu_memory_utilization",
+      label: "GPU Memory Utilization",
+      oldValue: setting.gpu_memory_utilization,
+      newValue: changes.gpu_memory_utilization,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>確認變更</DialogTitle>
+          <DialogDescription>
+            即將修改{" "}
+            <span className="font-mono font-medium">
+              {setting.model_component.name}
+            </span>{" "}
+            的設定
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {/* Diff table */}
+          <div className="rounded-md border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-slate-50 dark:bg-slate-900">
+                  <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
+                    欄位
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
+                    目前值
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
+                    新值
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {diffItems.map((item) => (
+                  <tr key={item.field} className="border-b last:border-b-0">
+                    <td className="px-3 py-2 font-medium">{item.label}</td>
+                    <td className="px-3 py-2">
+                      <span className="rounded bg-red-50 px-1.5 py-0.5 font-mono text-xs text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                        {formatValue(item.oldValue)}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className="rounded bg-green-50 px-1.5 py-0.5 font-mono text-xs text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                        {formatValue(item.newValue)}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Reason */}
+          {changes.reason && (
+            <div className="rounded-md bg-slate-50 p-3 dark:bg-slate-900">
+              <p className="text-xs font-medium text-slate-500">變更原因</p>
+              <p className="mt-1 text-sm">{changes.reason}</p>
+            </div>
+          )}
+
+          {/* Changed by */}
+          <p className="text-xs text-slate-500">
+            操作者: <span className="font-medium">{changes.changed_by}</span>
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            取消
+          </Button>
+          <Button onClick={onConfirm} disabled={isSubmitting}>
+            {isSubmitting ? "儲存中..." : "確認儲存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dev/src/components/edit-settings-form.tsx
+++ b/dev/src/components/edit-settings-form.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { X, Plus } from "lucide-react";
+import type { SettingRow } from "@/components/settings-table";
+
+interface EditSettingsFormProps {
+  setting: SettingRow;
+  onSave: (changes: EditChanges) => void;
+  onCancel: () => void;
+  isSaving?: boolean;
+}
+
+export interface EditChanges {
+  deploy?: boolean;
+  gpu_list?: string[];
+  replica?: number;
+  gpu_memory_utilization?: number;
+  reason?: string;
+  changed_by: string;
+  expected_updated_at: string;
+}
+
+export function EditSettingsForm({
+  setting,
+  onSave,
+  onCancel,
+  isSaving = false,
+}: EditSettingsFormProps) {
+  const [deploy, setDeploy] = useState(setting.deploy);
+  const [gpuList, setGpuList] = useState<string[]>(setting.gpu_list ?? []);
+  const [gpuInput, setGpuInput] = useState("");
+  const [replica, setReplica] = useState(setting.replica);
+  const [gpuMemUtil, setGpuMemUtil] = useState(
+    setting.gpu_memory_utilization ?? 0.85
+  );
+  const [reason, setReason] = useState("");
+  const [changedBy, setChangedBy] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const addGpu = useCallback(() => {
+    const trimmed = gpuInput.trim();
+    if (trimmed && !gpuList.includes(trimmed)) {
+      setGpuList((prev) => [...prev, trimmed]);
+      setGpuInput("");
+    }
+  }, [gpuInput, gpuList]);
+
+  const removeGpu = useCallback((index: number) => {
+    setGpuList((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleGpuKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        addGpu();
+      }
+    },
+    [addGpu]
+  );
+
+  const validate = useCallback(() => {
+    const newErrors: Record<string, string> = {};
+    if (!changedBy.trim()) {
+      newErrors.changed_by = "changed_by 為必填";
+    }
+    if (replica < 0) {
+      newErrors.replica = "Replica 不能為負數";
+    }
+    if (gpuMemUtil < 0 || gpuMemUtil > 1) {
+      newErrors.gpu_memory_utilization = "GPU Memory Utilization 必須介於 0 ~ 1";
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [changedBy, replica, gpuMemUtil]);
+
+  const handleSubmit = useCallback(() => {
+    if (!validate()) return;
+
+    const changes: EditChanges = {
+      changed_by: changedBy.trim(),
+      expected_updated_at: setting.updated_at,
+    };
+
+    if (deploy !== setting.deploy) changes.deploy = deploy;
+
+    const gpuListChanged =
+      JSON.stringify(gpuList) !== JSON.stringify(setting.gpu_list ?? []);
+    if (gpuListChanged) changes.gpu_list = gpuList;
+
+    if (replica !== setting.replica) changes.replica = replica;
+
+    const roundedUtil = Math.round(gpuMemUtil * 100) / 100;
+    if (roundedUtil !== setting.gpu_memory_utilization) {
+      changes.gpu_memory_utilization = roundedUtil;
+    }
+
+    if (reason.trim()) changes.reason = reason.trim();
+
+    // Check if there are actual changes
+    const hasChanges =
+      changes.deploy !== undefined ||
+      changes.gpu_list !== undefined ||
+      changes.replica !== undefined ||
+      changes.gpu_memory_utilization !== undefined;
+
+    if (!hasChanges) {
+      setErrors({ form: "沒有任何修改" });
+      return;
+    }
+
+    onSave(changes);
+  }, [
+    validate,
+    deploy,
+    gpuList,
+    replica,
+    gpuMemUtil,
+    reason,
+    changedBy,
+    setting,
+    onSave,
+  ]);
+
+  return (
+    <div className="space-y-5">
+      {/* Model info header */}
+      <div className="rounded-md bg-slate-50 p-3 dark:bg-slate-900">
+        <p className="font-mono text-sm font-medium">
+          {setting.model_component.name}
+        </p>
+        <p className="text-xs text-slate-500">
+          {setting.environment.name} / {setting.edition.name}
+        </p>
+      </div>
+
+      {/* Deploy toggle */}
+      <div className="flex items-center justify-between">
+        <Label htmlFor="edit-deploy">Deploy</Label>
+        <Switch
+          id="edit-deploy"
+          checked={deploy}
+          onCheckedChange={setDeploy}
+        />
+      </div>
+
+      {/* GPU List */}
+      <div className="space-y-2">
+        <Label>GPU List</Label>
+        <div className="flex flex-wrap gap-1">
+          {gpuList.map((gpu, i) => (
+            <Badge
+              key={i}
+              variant="secondary"
+              className="gap-1 font-mono text-xs"
+            >
+              {gpu}
+              <button
+                type="button"
+                onClick={() => removeGpu(i)}
+                className="ml-0.5 rounded-full hover:bg-slate-300 dark:hover:bg-slate-600"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={gpuInput}
+            onChange={(e) => setGpuInput(e.target.value)}
+            onKeyDown={handleGpuKeyDown}
+            placeholder="輸入 GPU 型號，按 Enter 新增"
+            className="flex-1"
+          />
+          <Button type="button" variant="outline" size="icon" onClick={addGpu}>
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Replica */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-replica">Replica</Label>
+        <Input
+          id="edit-replica"
+          type="number"
+          min={0}
+          value={replica}
+          onChange={(e) => setReplica(parseInt(e.target.value, 10) || 0)}
+        />
+        {errors.replica && (
+          <p className="text-xs text-red-500">{errors.replica}</p>
+        )}
+      </div>
+
+      {/* GPU Memory Utilization */}
+      <div className="space-y-2">
+        <Label>GPU Memory Utilization</Label>
+        <div className="flex items-center gap-3">
+          <Slider
+            value={gpuMemUtil}
+            onChange={setGpuMemUtil}
+            min={0}
+            max={1}
+            step={0.01}
+            className="flex-1"
+          />
+          <Input
+            type="number"
+            min={0}
+            max={1}
+            step={0.01}
+            value={gpuMemUtil}
+            onChange={(e) => {
+              const val = parseFloat(e.target.value);
+              if (!isNaN(val)) setGpuMemUtil(Math.min(1, Math.max(0, val)));
+            }}
+            className="w-20 font-mono"
+          />
+        </div>
+        {errors.gpu_memory_utilization && (
+          <p className="text-xs text-red-500">
+            {errors.gpu_memory_utilization}
+          </p>
+        )}
+      </div>
+
+      {/* Reason */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-reason">變更原因（選填）</Label>
+        <Textarea
+          id="edit-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="例如：增加 prod 副本數以應對流量"
+          maxLength={500}
+        />
+      </div>
+
+      {/* Changed By */}
+      <div className="space-y-2">
+        <Label htmlFor="edit-changed-by">
+          操作者 <span className="text-red-500">*</span>
+        </Label>
+        <Input
+          id="edit-changed-by"
+          value={changedBy}
+          onChange={(e) => setChangedBy(e.target.value)}
+          placeholder="例如：lynn.yang"
+          maxLength={100}
+        />
+        {errors.changed_by && (
+          <p className="text-xs text-red-500">{errors.changed_by}</p>
+        )}
+      </div>
+
+      {/* Form-level error */}
+      {errors.form && (
+        <p className="text-sm text-red-500">{errors.form}</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex justify-end gap-2 pt-2">
+        <Button variant="outline" onClick={onCancel} disabled={isSaving}>
+          取消
+        </Button>
+        <Button onClick={handleSubmit} disabled={isSaving}>
+          {isSaving ? "儲存中..." : "預覽變更"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/dev/src/components/settings-detail.tsx
+++ b/dev/src/components/settings-detail.tsx
@@ -1,14 +1,17 @@
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ModelTypeBadge } from "@/components/model-type-badge";
+import { Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SettingRow } from "@/components/settings-table";
 
 interface SettingsDetailProps {
   setting: SettingRow;
   className?: string;
+  onEdit?: (setting: SettingRow) => void;
 }
 
-export function SettingsDetail({ setting, className }: SettingsDetailProps) {
+export function SettingsDetail({ setting, className, onEdit }: SettingsDetailProps) {
   const { model_component, environment, edition, deploy, gpu_list, replica, gpu_memory_utilization, extra_settings, updated_at } = setting;
 
   return (
@@ -25,7 +28,20 @@ export function SettingsDetail({ setting, className }: SettingsDetailProps) {
             </p>
           )}
         </div>
-        <ModelTypeBadge type={model_component.type} size="md" />
+        <div className="flex items-center gap-2">
+          <ModelTypeBadge type={model_component.type} size="md" />
+          {onEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onEdit(setting)}
+              className="gap-1"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              編輯
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Deploy status */}

--- a/dev/src/components/settings-table.tsx
+++ b/dev/src/components/settings-table.tsx
@@ -34,6 +34,7 @@ import {
   ChevronRight,
   ChevronDown,
   ChevronRight as ChevronRightIcon,
+  Pencil,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -73,6 +74,7 @@ interface SettingsTableProps {
   onSortingChange: (sortBy: string, sortOrder: "asc" | "desc") => void;
   sortBy?: string;
   sortOrder?: "asc" | "desc";
+  onEditSetting?: (setting: SettingRow) => void;
 }
 
 // Sub-components
@@ -169,7 +171,7 @@ function SettingsDetail({ setting }: { setting: SettingRow }) {
 }
 
 // Column definitions
-function createColumns(): ColumnDef<SettingRow>[] {
+function createColumns(onEdit?: (setting: SettingRow) => void): ColumnDef<SettingRow>[] {
   return [
     {
       id: "expander",
@@ -250,6 +252,30 @@ function createColumns(): ColumnDef<SettingRow>[] {
         <GpuMemBar value={row.original.gpu_memory_utilization} />
       ),
     },
+    ...(onEdit
+      ? [
+          {
+            id: "actions",
+            header: () => null,
+            cell: ({ row }: { row: { original: SettingRow } }) => (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  onEdit(row.original);
+                }}
+                aria-label="編輯設定"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            ),
+            enableSorting: false,
+            size: 48,
+          } as ColumnDef<SettingRow>,
+        ]
+      : []),
   ];
 }
 
@@ -262,8 +288,9 @@ export function SettingsTable({
   onSortingChange,
   sortBy = "name",
   sortOrder = "asc",
+  onEditSetting,
 }: SettingsTableProps) {
-  const columns = React.useMemo(() => createColumns(), []);
+  const columns = React.useMemo(() => createColumns(onEditSetting), [onEditSetting]);
   const [expanded, setExpanded] = React.useState<ExpandedState>({});
 
   // Convert external sort state to TanStack sorting state

--- a/dev/src/components/side-by-side-diff.tsx
+++ b/dev/src/components/side-by-side-diff.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronRight, Plus, Minus, Pencil } from "lucide-react";
+
+interface ChangeDiff {
+  [field: string]: { version_a: unknown; version_b: unknown };
+}
+
+interface ChangeEntry {
+  model_component_name: string;
+  model_type: string;
+  environment: string;
+  edition: string;
+  change_type: "added" | "removed" | "modified";
+  diff: ChangeDiff;
+}
+
+interface CompareSummary {
+  added: number;
+  removed: number;
+  modified: number;
+  unchanged: number;
+}
+
+interface CompareResult {
+  version_a: { id: string; name: string };
+  version_b: { id: string; name: string };
+  summary: CompareSummary;
+  changes: ChangeEntry[];
+}
+
+interface SideBySideDiffProps {
+  result: CompareResult;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "-";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) return value.length > 0 ? value.join(", ") : "(empty)";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+const changeTypeConfig = {
+  added: {
+    label: "新增",
+    icon: Plus,
+    badgeClass: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+    borderClass: "border-l-green-500",
+  },
+  removed: {
+    label: "移除",
+    icon: Minus,
+    badgeClass: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    borderClass: "border-l-red-500",
+  },
+  modified: {
+    label: "修改",
+    icon: Pencil,
+    badgeClass: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+    borderClass: "border-l-yellow-500",
+  },
+};
+
+function ChangeCard({ change, versionA, versionB }: {
+  change: ChangeEntry;
+  versionA: string;
+  versionB: string;
+}) {
+  const [expanded, setExpanded] = useState(change.change_type === "modified");
+  const config = changeTypeConfig[change.change_type];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-l-4",
+        config.borderClass
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/50"
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+              config.badgeClass
+            )}
+          >
+            <Icon className="h-3 w-3" />
+            {config.label}
+          </span>
+          <span className="font-mono text-sm font-medium">
+            {change.model_component_name}
+          </span>
+          <Badge variant="outline" className="text-xs">
+            {change.model_type}
+          </Badge>
+          <span className="text-xs text-slate-500">
+            {change.environment} / {change.edition}
+          </span>
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-slate-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-slate-400" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t px-4 py-3">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-slate-500">
+                <th className="pb-2 text-left font-medium">欄位</th>
+                <th className="pb-2 text-left font-medium">{versionA}</th>
+                <th className="pb-2 text-left font-medium">{versionB}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(change.diff).map(([field, values]) => (
+                <tr key={field} className="border-t">
+                  <td className="py-2 font-medium">{field}</td>
+                  <td className="py-2">
+                    <span
+                      className={cn(
+                        "rounded px-1.5 py-0.5 font-mono text-xs",
+                        change.change_type === "added"
+                          ? "text-slate-400"
+                          : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                      )}
+                    >
+                      {formatValue(values.version_a)}
+                    </span>
+                  </td>
+                  <td className="py-2">
+                    <span
+                      className={cn(
+                        "rounded px-1.5 py-0.5 font-mono text-xs",
+                        change.change_type === "removed"
+                          ? "text-slate-400"
+                          : "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      )}
+                    >
+                      {formatValue(values.version_b)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SideBySideDiff({ result }: SideBySideDiffProps) {
+  const { summary, changes, version_a, version_b } = result;
+
+  // Group by change type
+  const added = changes.filter((c) => c.change_type === "added");
+  const removed = changes.filter((c) => c.change_type === "removed");
+  const modified = changes.filter((c) => c.change_type === "modified");
+
+  return (
+    <div className="space-y-6">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Card className="p-4">
+          <p className="text-xs font-medium text-slate-500">新增</p>
+          <p className="mt-1 text-2xl font-bold text-green-600">
+            {summary.added}
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs font-medium text-slate-500">移除</p>
+          <p className="mt-1 text-2xl font-bold text-red-600">
+            {summary.removed}
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs font-medium text-slate-500">修改</p>
+          <p className="mt-1 text-2xl font-bold text-yellow-600">
+            {summary.modified}
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs font-medium text-slate-500">未變更</p>
+          <p className="mt-1 text-2xl font-bold text-slate-400">
+            {summary.unchanged}
+          </p>
+        </Card>
+      </div>
+
+      {/* Changes list */}
+      {changes.length === 0 ? (
+        <div className="flex h-32 items-center justify-center rounded-lg border border-dashed text-sm text-slate-500">
+          兩個版本的設定完全相同
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* Modified */}
+          {modified.length > 0 && (
+            <section>
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-yellow-700 dark:text-yellow-400">
+                <Pencil className="h-4 w-4" />
+                修改（{modified.length}）
+              </h3>
+              <div className="space-y-2">
+                {modified.map((c, i) => (
+                  <ChangeCard
+                    key={`mod-${i}`}
+                    change={c}
+                    versionA={version_a.name}
+                    versionB={version_b.name}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Added */}
+          {added.length > 0 && (
+            <section>
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-green-700 dark:text-green-400">
+                <Plus className="h-4 w-4" />
+                新增（{added.length}）
+              </h3>
+              <div className="space-y-2">
+                {added.map((c, i) => (
+                  <ChangeCard
+                    key={`add-${i}`}
+                    change={c}
+                    versionA={version_a.name}
+                    versionB={version_b.name}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Removed */}
+          {removed.length > 0 && (
+            <section>
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-red-700 dark:text-red-400">
+                <Minus className="h-4 w-4" />
+                移除（{removed.length}）
+              </h3>
+              <div className="space-y-2">
+                {removed.map((c, i) => (
+                  <ChangeCard
+                    key={`rem-${i}`}
+                    change={c}
+                    versionA={version_a.name}
+                    versionB={version_b.name}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dev/src/components/sidebar.tsx
+++ b/dev/src/components/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { LayoutDashboard, Settings2, Table2 } from "lucide-react";
+import { LayoutDashboard, Settings2, Table2, GitCompareArrows } from "lucide-react";
 
 const navItems = [
   {
@@ -16,6 +16,12 @@ const navItems = [
     name: "Settings",
     href: "/settings",
     icon: Table2,
+    exact: false,
+  },
+  {
+    name: "版本比較",
+    href: "/compare",
+    icon: GitCompareArrows,
     exact: false,
   },
 ];

--- a/dev/src/components/ui/dialog.tsx
+++ b/dev/src/components/ui/dialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+function Dialog({ open, onOpenChange, children }: DialogProps) {
+  React.useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={() => onOpenChange(false)}
+      />
+      {/* Content wrapper */}
+      {children}
+    </div>
+  );
+}
+
+interface DialogContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function DialogContent({ children, className }: DialogContentProps) {
+  return (
+    <div
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-950",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DialogHeader({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("mb-4 space-y-1.5", className)}>{children}</div>
+  );
+}
+
+function DialogTitle({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <h2
+      className={cn(
+        "text-lg font-semibold leading-none tracking-tight",
+        className
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function DialogDescription({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={cn("text-sm text-slate-500 dark:text-slate-400", className)}>
+      {children}
+    </p>
+  );
+}
+
+function DialogFooter({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "mt-6 flex justify-end gap-2",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DialogClose({
+  onClose,
+  className,
+}: {
+  onClose: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      onClick={onClose}
+      className={cn(
+        "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2",
+        className
+      )}
+    >
+      <X className="h-4 w-4" />
+      <span className="sr-only">關閉</span>
+    </button>
+  );
+}
+
+export {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+};

--- a/dev/src/components/ui/label.tsx
+++ b/dev/src/components/ui/label.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <label
+        ref={ref}
+        className={cn(
+          "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Label.displayName = "Label";
+
+export { Label };

--- a/dev/src/components/ui/slider.tsx
+++ b/dev/src/components/ui/slider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface SliderProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  ({ value, onChange, min = 0, max = 1, step = 0.01, disabled = false, className }, ref) => {
+    const percentage = ((value - min) / (max - min)) * 100;
+
+    return (
+      <div className={cn("relative flex w-full items-center", className)}>
+        <input
+          ref={ref}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-slate-900 dark:bg-slate-700 dark:accent-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+          style={{
+            background: `linear-gradient(to right, rgb(15, 23, 42) ${percentage}%, rgb(226, 232, 240) ${percentage}%)`,
+          }}
+        />
+      </div>
+    );
+  }
+);
+Slider.displayName = "Slider";
+
+export { Slider };

--- a/dev/src/components/ui/textarea.tsx
+++ b/dev/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/dev/src/components/version-compare.tsx
+++ b/dev/src/components/version-compare.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import React, { useState, useCallback, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { ArrowRightLeft } from "lucide-react";
+
+interface Version {
+  id: string;
+  name: string;
+}
+
+interface Environment {
+  id: string;
+  name: string;
+}
+
+interface Edition {
+  id: string;
+  name: string;
+}
+
+interface VersionCompareProps {
+  onCompare: (params: {
+    versionAId: string;
+    versionBId: string;
+    environmentId?: string;
+    editionId?: string;
+  }) => void;
+  isLoading?: boolean;
+}
+
+export function VersionCompare({ onCompare, isLoading }: VersionCompareProps) {
+  const [versions, setVersions] = useState<Version[]>([]);
+  const [versionAId, setVersionAId] = useState("");
+  const [versionBId, setVersionBId] = useState("");
+  const [environmentId, setEnvironmentId] = useState<string | undefined>();
+  const [editionId, setEditionId] = useState<string | undefined>();
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [editions, setEditions] = useState<Edition[]>([]);
+
+  // Fetch versions
+  useEffect(() => {
+    async function fetchVersions() {
+      try {
+        const res = await fetch("/api/v1/versions?per_page=100");
+        if (res.ok) {
+          const data = await res.json();
+          setVersions(data.data ?? []);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    fetchVersions();
+  }, []);
+
+  // Fetch environments and editions when version A is selected
+  useEffect(() => {
+    if (!versionAId) return;
+    async function fetchFilters() {
+      try {
+        const res = await fetch(
+          `/api/v1/settings?version_id=${versionAId}&per_page=1`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setEnvironments(data.filters?.available_environments ?? []);
+          setEditions(data.filters?.available_editions ?? []);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    fetchFilters();
+  }, [versionAId]);
+
+  const handleCompare = useCallback(() => {
+    if (!versionAId || !versionBId) return;
+    onCompare({
+      versionAId,
+      versionBId,
+      environmentId,
+      editionId,
+    });
+  }, [versionAId, versionBId, environmentId, editionId, onCompare]);
+
+  const canCompare = versionAId && versionBId && versionAId !== versionBId;
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <div className="flex flex-wrap items-end gap-4">
+        {/* Version A */}
+        <div className="space-y-1.5">
+          <Label>Version A（基準）</Label>
+          <Select value={versionAId} onValueChange={setVersionAId}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="選擇版本 A" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id}>
+                  {v.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <ArrowRightLeft className="mb-2 h-5 w-5 text-slate-400" />
+
+        {/* Version B */}
+        <div className="space-y-1.5">
+          <Label>Version B（比較）</Label>
+          <Select value={versionBId} onValueChange={setVersionBId}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="選擇版本 B" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id}>
+                  {v.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Environment filter */}
+        <div className="space-y-1.5">
+          <Label>Environment（選填）</Label>
+          <Select
+            value={environmentId ?? "all"}
+            onValueChange={(v) =>
+              setEnvironmentId(v === "all" ? undefined : v)
+            }
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="全部環境" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全部環境</SelectItem>
+              {environments.map((e) => (
+                <SelectItem key={e.id} value={e.id}>
+                  {e.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Edition filter */}
+        <div className="space-y-1.5">
+          <Label>Edition（選填）</Label>
+          <Select
+            value={editionId ?? "all"}
+            onValueChange={(v) => setEditionId(v === "all" ? undefined : v)}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="全部 Edition" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全部 Edition</SelectItem>
+              {editions.map((e) => (
+                <SelectItem key={e.id} value={e.id}>
+                  {e.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Compare button */}
+        <Button onClick={handleCompare} disabled={!canCompare || isLoading}>
+          {isLoading ? "比較中..." : "比較"}
+        </Button>
+      </div>
+
+      {versionAId && versionBId && versionAId === versionBId && (
+        <p className="text-sm text-red-500">不允許同一版本自我比較</p>
+      )}
+    </div>
+  );
+}

--- a/dev/src/lib/diff.ts
+++ b/dev/src/lib/diff.ts
@@ -1,0 +1,48 @@
+/**
+ * 計算兩個 settings 物件之間的差異
+ * @returns diff 物件: { field: { old, new } }，只包含有變更的欄位
+ */
+export function computeDiff(
+  oldValues: Record<string, unknown>,
+  newValues: Record<string, unknown>
+): Record<string, { old: unknown; new: unknown }> {
+  const diff: Record<string, { old: unknown; new: unknown }> = {};
+
+  for (const key of Object.keys(newValues)) {
+    const oldVal = oldValues[key];
+    const newVal = newValues[key];
+
+    if (!isEqual(oldVal, newVal)) {
+      diff[key] = { old: oldVal, new: newVal };
+    }
+  }
+
+  return diff;
+}
+
+/**
+ * 深度相等比較（支援 primitive, array, object）
+ */
+function isEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (a === undefined || b === undefined) return false;
+  if (typeof a !== typeof b) return false;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((val, i) => isEqual(val, b[i]));
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
+    for (const key of keys) {
+      if (!isEqual(aObj[key], bObj[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/dev/src/lib/queries/compare.ts
+++ b/dev/src/lib/queries/compare.ts
@@ -1,0 +1,270 @@
+import { db } from "@/db";
+import {
+  modelSettings,
+  modelComponents,
+  environments,
+  editions,
+  versions,
+} from "@/db/schema";
+import { eq, and, sql } from "drizzle-orm";
+
+export interface CompareParams {
+  versionAId: string;
+  versionBId: string;
+  environmentId?: string;
+  editionId?: string;
+}
+
+interface SettingRecord {
+  settingId: string;
+  modelComponentName: string;
+  modelComponentType: string;
+  environmentName: string;
+  editionName: string;
+  deploy: boolean;
+  gpuList: string[];
+  replica: number;
+  gpuMemoryUtilization: number | null;
+  extraSettings: Record<string, unknown>;
+}
+
+interface ChangeDiff {
+  [field: string]: { version_a: unknown; version_b: unknown };
+}
+
+interface ChangeEntry {
+  model_component_name: string;
+  model_type: string;
+  environment: string;
+  edition: string;
+  change_type: "added" | "removed" | "modified";
+  diff: ChangeDiff;
+}
+
+function buildMatchingKey(r: SettingRecord): string {
+  return `${r.modelComponentName}|${r.environmentName}|${r.editionName}`;
+}
+
+const COMPARE_FIELDS = [
+  "deploy",
+  "gpu_list",
+  "replica",
+  "gpu_memory_utilization",
+  "extra_settings",
+] as const;
+
+function getFieldValue(record: SettingRecord, field: string): unknown {
+  switch (field) {
+    case "deploy":
+      return record.deploy;
+    case "gpu_list":
+      return record.gpuList;
+    case "replica":
+      return record.replica;
+    case "gpu_memory_utilization":
+      return record.gpuMemoryUtilization;
+    case "extra_settings":
+      return record.extraSettings;
+    default:
+      return undefined;
+  }
+}
+
+function isEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (a === undefined || b === undefined) return a === b;
+  if (typeof a !== typeof b) return false;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((val, i) => isEqual(val, b[i]));
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
+    for (const key of keys) {
+      if (!isEqual(aObj[key], bObj[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+async function getSettingsForVersion(
+  versionId: string,
+  environmentId?: string,
+  editionId?: string
+): Promise<SettingRecord[]> {
+  const conditions = [eq(modelComponents.versionId, versionId)];
+  if (environmentId) {
+    conditions.push(eq(modelSettings.environmentId, environmentId));
+  }
+  if (editionId) {
+    conditions.push(eq(modelSettings.editionId, editionId));
+  }
+
+  const rows = await db
+    .select({
+      settingId: modelSettings.id,
+      modelComponentName: modelComponents.name,
+      modelComponentType: modelComponents.type,
+      environmentName: environments.name,
+      editionName: editions.name,
+      deploy: modelSettings.deploy,
+      gpuList: modelSettings.gpuList,
+      replica: modelSettings.replica,
+      gpuMemoryUtilization: modelSettings.gpuMemoryUtilization,
+      extraSettings: modelSettings.extraSettings,
+    })
+    .from(modelSettings)
+    .innerJoin(
+      modelComponents,
+      eq(modelSettings.modelComponentId, modelComponents.id)
+    )
+    .innerJoin(environments, eq(modelSettings.environmentId, environments.id))
+    .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+    .where(and(...conditions));
+
+  return rows.map((r) => ({
+    settingId: r.settingId,
+    modelComponentName: r.modelComponentName,
+    modelComponentType: r.modelComponentType,
+    environmentName: r.environmentName,
+    editionName: r.editionName,
+    deploy: r.deploy,
+    gpuList: (r.gpuList as string[]) ?? [],
+    replica: r.replica,
+    gpuMemoryUtilization: r.gpuMemoryUtilization
+      ? parseFloat(r.gpuMemoryUtilization)
+      : null,
+    extraSettings: (r.extraSettings as Record<string, unknown>) ?? {},
+  }));
+}
+
+export async function compareVersions(params: CompareParams) {
+  const { versionAId, versionBId, environmentId, editionId } = params;
+
+  // 1. Validate versions exist
+  const [versionA, versionB] = await Promise.all([
+    db.select().from(versions).where(eq(versions.id, versionAId)).limit(1),
+    db.select().from(versions).where(eq(versions.id, versionBId)).limit(1),
+  ]);
+
+  if (versionA.length === 0) {
+    throw new CompareError("NOT_FOUND", `Version A not found: ${versionAId}`, 404);
+  }
+  if (versionB.length === 0) {
+    throw new CompareError("NOT_FOUND", `Version B not found: ${versionBId}`, 404);
+  }
+
+  // 2. Get settings for both versions
+  const [settingsA, settingsB] = await Promise.all([
+    getSettingsForVersion(versionAId, environmentId, editionId),
+    getSettingsForVersion(versionBId, environmentId, editionId),
+  ]);
+
+  // 3. Build maps by matching key
+  const mapA = new Map<string, SettingRecord>();
+  for (const s of settingsA) {
+    mapA.set(buildMatchingKey(s), s);
+  }
+  const mapB = new Map<string, SettingRecord>();
+  for (const s of settingsB) {
+    mapB.set(buildMatchingKey(s), s);
+  }
+
+  // 4. Compare
+  const allKeys = new Set([...mapA.keys(), ...mapB.keys()]);
+  const changes: ChangeEntry[] = [];
+  let added = 0;
+  let removed = 0;
+  let modified = 0;
+  let unchanged = 0;
+
+  for (const key of allKeys) {
+    const a = mapA.get(key);
+    const b = mapB.get(key);
+
+    if (a && !b) {
+      // Removed in version B
+      removed++;
+      const diff: ChangeDiff = {};
+      for (const field of COMPARE_FIELDS) {
+        const val = getFieldValue(a, field);
+        if (val !== null && val !== undefined) {
+          diff[field] = { version_a: val, version_b: null };
+        }
+      }
+      changes.push({
+        model_component_name: a.modelComponentName,
+        model_type: a.modelComponentType,
+        environment: a.environmentName,
+        edition: a.editionName,
+        change_type: "removed",
+        diff,
+      });
+    } else if (!a && b) {
+      // Added in version B
+      added++;
+      const diff: ChangeDiff = {};
+      for (const field of COMPARE_FIELDS) {
+        const val = getFieldValue(b, field);
+        if (val !== null && val !== undefined) {
+          diff[field] = { version_a: null, version_b: val };
+        }
+      }
+      changes.push({
+        model_component_name: b.modelComponentName,
+        model_type: b.modelComponentType,
+        environment: b.environmentName,
+        edition: b.editionName,
+        change_type: "added",
+        diff,
+      });
+    } else if (a && b) {
+      // Both exist - check for modifications
+      const diff: ChangeDiff = {};
+      for (const field of COMPARE_FIELDS) {
+        const valA = getFieldValue(a, field);
+        const valB = getFieldValue(b, field);
+        if (!isEqual(valA, valB)) {
+          diff[field] = { version_a: valA, version_b: valB };
+        }
+      }
+      if (Object.keys(diff).length > 0) {
+        modified++;
+        changes.push({
+          model_component_name: a.modelComponentName,
+          model_type: a.modelComponentType,
+          environment: a.environmentName,
+          edition: a.editionName,
+          change_type: "modified",
+          diff,
+        });
+      } else {
+        unchanged++;
+      }
+    }
+  }
+
+  return {
+    version_a: { id: versionA[0].id, name: versionA[0].name },
+    version_b: { id: versionB[0].id, name: versionB[0].name },
+    summary: { added, removed, modified, unchanged },
+    changes,
+  };
+}
+
+export class CompareError extends Error {
+  code: string;
+  status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}

--- a/dev/src/lib/queries/settings.ts
+++ b/dev/src/lib/queries/settings.ts
@@ -4,8 +4,10 @@ import {
   modelComponents,
   environments,
   editions,
+  changeHistories,
 } from "@/db/schema";
 import { eq, and, ilike, sql, asc, desc } from "drizzle-orm";
+import { computeDiff } from "@/lib/diff";
 
 export interface SettingsQueryParams {
   versionId: string;
@@ -270,4 +272,126 @@ export async function getSettingById(settingId: string) {
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),
   };
+}
+
+export interface SettingChanges {
+  deploy?: boolean;
+  gpu_list?: string[];
+  replica?: number;
+  gpu_memory_utilization?: number;
+  extra_settings?: Record<string, unknown>;
+}
+
+export async function updateSetting(
+  settingId: string,
+  changes: SettingChanges,
+  changedBy: string,
+  reason?: string,
+  expectedUpdatedAt?: string
+): Promise<{ setting: ReturnType<typeof getSettingById> extends Promise<infer T> ? T : never; changeHistoryId: string }> {
+  // 1. Get current setting (raw DB row)
+  const currentRows = await db
+    .select()
+    .from(modelSettings)
+    .where(eq(modelSettings.id, settingId))
+    .limit(1);
+
+  if (currentRows.length === 0) {
+    throw new UpdateSettingError("NOT_FOUND", "Setting not found", 404);
+  }
+
+  const current = currentRows[0];
+
+  // 2. Optimistic lock check
+  if (expectedUpdatedAt) {
+    const expected = new Date(expectedUpdatedAt).getTime();
+    const actual = current.updatedAt.getTime();
+    if (expected !== actual) {
+      throw new UpdateSettingError(
+        "CONFLICT",
+        "Setting has been modified by another user. Please refresh and try again.",
+        409
+      );
+    }
+  }
+
+  // 3. Compute diff
+  const oldValues: Record<string, unknown> = {};
+  const newValues: Record<string, unknown> = {};
+
+  if (changes.deploy !== undefined) {
+    oldValues.deploy = current.deploy;
+    newValues.deploy = changes.deploy;
+  }
+  if (changes.gpu_list !== undefined) {
+    oldValues.gpu_list = current.gpuList ?? [];
+    newValues.gpu_list = changes.gpu_list;
+  }
+  if (changes.replica !== undefined) {
+    oldValues.replica = current.replica;
+    newValues.replica = changes.replica;
+  }
+  if (changes.gpu_memory_utilization !== undefined) {
+    oldValues.gpu_memory_utilization = current.gpuMemoryUtilization
+      ? parseFloat(current.gpuMemoryUtilization)
+      : null;
+    newValues.gpu_memory_utilization = changes.gpu_memory_utilization;
+  }
+  if (changes.extra_settings !== undefined) {
+    oldValues.extra_settings = current.extraSettings ?? {};
+    newValues.extra_settings = changes.extra_settings;
+  }
+
+  const diff = computeDiff(oldValues, newValues);
+
+  if (Object.keys(diff).length === 0) {
+    throw new UpdateSettingError(
+      "INVALID_INPUT",
+      "No changes detected - submitted values are identical to current values",
+      400
+    );
+  }
+
+  // 4. Transaction: update setting + insert change history
+  const now = new Date();
+  const changeHistoryId = crypto.randomUUID();
+
+  await db.transaction(async (tx) => {
+    const updateData: Record<string, unknown> = { updatedAt: now };
+    if (changes.deploy !== undefined) updateData.deploy = changes.deploy;
+    if (changes.gpu_list !== undefined) updateData.gpuList = changes.gpu_list;
+    if (changes.replica !== undefined) updateData.replica = changes.replica;
+    if (changes.gpu_memory_utilization !== undefined) {
+      updateData.gpuMemoryUtilization = String(changes.gpu_memory_utilization);
+    }
+    if (changes.extra_settings !== undefined) updateData.extraSettings = changes.extra_settings;
+
+    await tx
+      .update(modelSettings)
+      .set(updateData)
+      .where(eq(modelSettings.id, settingId));
+
+    await tx.insert(changeHistories).values({
+      id: changeHistoryId,
+      modelSettingId: settingId,
+      changedBy,
+      changeType: "UPDATE",
+      diff,
+      reason: reason || null,
+    });
+  });
+
+  // 5. Return updated setting
+  const setting = await getSettingById(settingId);
+  return { setting: setting!, changeHistoryId };
+}
+
+export class UpdateSettingError extends Error {
+  code: string;
+  status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
 }


### PR DESCRIPTION
## Summary
- PATCH /api/v1/settings/:id with optimistic locking + change history
- Edit settings form (deploy, gpuList, replica, gpu_memory_utilization)
- Confirm dialog with diff preview
- GET /api/v1/compare for version A vs B comparison
- Side-by-side diff UI
- Compare page with version selector + environment/edition filters

Closes #9
Closes #11

## Test plan
- [ ] PATCH setting with valid changes returns 200 + creates ChangeHistory
- [ ] PATCH with no actual changes returns 400
- [ ] PATCH with invalid replica/gpu_mem returns 400
- [ ] PATCH with stale expected_updated_at returns 409
- [ ] PATCH non-existent setting returns 404
- [ ] GET /api/v1/compare with two versions returns diff
- [ ] GET /api/v1/compare same version returns 400
- [ ] Edit form UI renders correctly and validates input
- [ ] Confirm dialog shows diff preview before save
- [ ] Compare page shows summary cards + grouped changes
- [ ] Sidebar shows Compare link