### PR TITLE
feat: F-005 變更歷史紀錄

### DIFF
--- a/dev/__tests__/api/history.test.ts
+++ b/dev/__tests__/api/history.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// Schema matching the one in the API route
+const historyQuerySchema = z.object({
+  version_id: z.string().uuid().optional(),
+  environment_id: z.string().uuid().optional(),
+  edition_id: z.string().uuid().optional(),
+  model_component_id: z.string().uuid().optional(),
+  changed_by: z.string().optional(),
+  change_type: z.enum(["CREATE", "UPDATE", "DELETE"]).optional(),
+  from_date: z.string().datetime().optional(),
+  to_date: z.string().datetime().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+describe("GET /api/v1/history - query validation", () => {
+  it("should accept empty params with defaults", () => {
+    const result = historyQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(1);
+      expect(result.data.per_page).toBe(20);
+    }
+  });
+
+  it("should accept valid UUID filters", () => {
+    const result = historyQuerySchema.safeParse({
+      version_id: "550e8400-e29b-41d4-a716-446655440000",
+      environment_id: "550e8400-e29b-41d4-a716-446655440001",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid UUID", () => {
+    const result = historyQuerySchema.safeParse({
+      version_id: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid change_type", () => {
+    for (const type of ["CREATE", "UPDATE", "DELETE"]) {
+      const result = historyQuerySchema.safeParse({ change_type: type });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject invalid change_type", () => {
+    const result = historyQuerySchema.safeParse({ change_type: "INVALID" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid date range", () => {
+    const result = historyQuerySchema.safeParse({
+      from_date: "2026-04-01T00:00:00Z",
+      to_date: "2026-04-02T23:59:59Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should coerce page and per_page from strings", () => {
+    const result = historyQuerySchema.safeParse({
+      page: "3",
+      per_page: "50",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(3);
+      expect(result.data.per_page).toBe(50);
+    }
+  });
+
+  it("should reject per_page > 100", () => {
+    const result = historyQuerySchema.safeParse({ per_page: "200" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject page < 1", () => {
+    const result = historyQuerySchema.safeParse({ page: "0" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept changed_by filter", () => {
+    const result = historyQuerySchema.safeParse({ changed_by: "lynn.yang" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.changed_by).toBe("lynn.yang");
+    }
+  });
+});
+
+describe("History response structure", () => {
+  it("should have correct pagination structure", () => {
+    const pagination = {
+      page: 1,
+      per_page: 20,
+      total: 150,
+      total_pages: 8,
+    };
+
+    expect(pagination.total_pages).toBe(Math.ceil(pagination.total / pagination.per_page));
+  });
+
+  it("should format history item correctly", () => {
+    const item = {
+      id: "uuid-1",
+      model_setting: {
+        id: "setting-uuid",
+        model_component: { name: "asr-general", type: "ASR" },
+        environment: { name: "prod" },
+        edition: { name: "pro" },
+      },
+      changed_by: "lynn.yang",
+      change_type: "UPDATE",
+      diff: {
+        deploy: { old: false, new: true },
+        replica: { old: 1, new: 3 },
+      },
+      reason: "增加 prod 副本數",
+      created_at: "2026-04-02T10:30:00.000Z",
+    };
+
+    expect(item.model_setting.model_component.name).toBe("asr-general");
+    expect(item.change_type).toBe("UPDATE");
+    expect(item.diff.replica.old).toBe(1);
+    expect(item.diff.replica.new).toBe(3);
+  });
+
+  it("CREATE diff should have null old values", () => {
+    const createDiff = {
+      deploy: { old: null, new: false },
+      replica: { old: null, new: 1 },
+    };
+
+    for (const value of Object.values(createDiff)) {
+      expect(value.old).toBeNull();
+    }
+  });
+
+  it("DELETE diff should have null new values", () => {
+    const deleteDiff = {
+      deploy: { old: true, new: null },
+      replica: { old: 3, new: null },
+    };
+
+    for (const value of Object.values(deleteDiff)) {
+      expect(value.new).toBeNull();
+    }
+  });
+});

--- a/dev/package-lock.json
+++ b/dev/package-lock.json
@@ -8,8 +8,10 @@
       "name": "sync-model-gp",
       "version": "1.0.0",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@tanstack/react-table": "^8.20.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "drizzle-orm": "^0.45.0",
         "lucide-react": "^0.500.0",
         "next": "^16.2.0",
@@ -2173,6 +2175,207 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2995,8 +3198,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4328,7 +4532,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4390,6 +4594,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/dev/package.json
+++ b/dev/package.json
@@ -15,8 +15,10 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@tanstack/react-table": "^8.20.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "drizzle-orm": "^0.45.0",
     "lucide-react": "^0.500.0",
     "next": "^16.2.0",

--- a/dev/src/app/api/v1/history/[historyId]/route.ts
+++ b/dev/src/app/api/v1/history/[historyId]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server";
+import { successResponse, errorResponse } from "@/lib/api";
+import { getHistoryById } from "@/lib/queries/history";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ historyId: string }> }
+) {
+  try {
+    const { historyId } = await params;
+
+    const history = await getHistoryById(historyId);
+    if (!history) {
+      return errorResponse("NOT_FOUND", "History record not found", 404);
+    }
+
+    return successResponse(history);
+  } catch (error) {
+    console.error("Failed to fetch history detail:", error);
+    return errorResponse(
+      "INTERNAL_ERROR",
+      "Failed to fetch history detail",
+      500
+    );
+  }
+}

--- a/dev/src/app/api/v1/history/route.ts
+++ b/dev/src/app/api/v1/history/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { successResponse, errorResponse } from "@/lib/api";
+import { queryHistory } from "@/lib/queries/history";
+
+const historyQuerySchema = z.object({
+  version_id: z.string().uuid().optional(),
+  environment_id: z.string().uuid().optional(),
+  edition_id: z.string().uuid().optional(),
+  model_component_id: z.string().uuid().optional(),
+  changed_by: z.string().optional(),
+  change_type: z.enum(["CREATE", "UPDATE", "DELETE"]).optional(),
+  from_date: z.string().datetime().optional(),
+  to_date: z.string().datetime().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const rawParams: Record<string, string> = {};
+    for (const [key, value] of searchParams.entries()) {
+      rawParams[key] = value;
+    }
+
+    const parseResult = historyQuerySchema.safeParse(rawParams);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", "),
+        400
+      );
+    }
+
+    const params = parseResult.data;
+
+    const result = await queryHistory({
+      versionId: params.version_id,
+      environmentId: params.environment_id,
+      editionId: params.edition_id,
+      modelComponentId: params.model_component_id,
+      changedBy: params.changed_by,
+      changeType: params.change_type,
+      fromDate: params.from_date,
+      toDate: params.to_date,
+      page: params.page,
+      perPage: params.per_page,
+    });
+
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch history:", error);
+    return errorResponse("INTERNAL_ERROR", "Failed to fetch history", 500);
+  }
+}

--- a/dev/src/app/api/v1/settings/[settingId]/history/route.ts
+++ b/dev/src/app/api/v1/settings/[settingId]/history/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { successResponse, errorResponse } from "@/lib/api";
+import { getSettingById } from "@/lib/queries/settings";
+import { getSettingHistory } from "@/lib/queries/history";
+
+const settingHistoryQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ settingId: string }> }
+) {
+  try {
+    const { settingId } = await params;
+
+    // Verify setting exists
+    const setting = await getSettingById(settingId);
+    if (!setting) {
+      return errorResponse("NOT_FOUND", "Setting not found", 404);
+    }
+
+    const { searchParams } = new URL(request.url);
+    const rawParams: Record<string, string> = {};
+    for (const [key, value] of searchParams.entries()) {
+      rawParams[key] = value;
+    }
+
+    const parseResult = settingHistoryQuerySchema.safeParse(rawParams);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", "),
+        400
+      );
+    }
+
+    const { page, per_page } = parseResult.data;
+    const result = await getSettingHistory(settingId, page, per_page);
+
+    return successResponse(result);
+  } catch (error) {
+    console.error("Failed to fetch setting history:", error);
+    return errorResponse(
+      "INTERNAL_ERROR",
+      "Failed to fetch setting history",
+      500
+    );
+  }
+}

--- a/dev/src/app/history/page.tsx
+++ b/dev/src/app/history/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useHistory } from "@/hooks/use-history";
+import { HistoryTimeline } from "@/components/history-timeline";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const CHANGE_TYPES = ["CREATE", "UPDATE", "DELETE"] as const;
+
+const changeTypeBadgeStyles: Record<string, string> = {
+  CREATE:
+    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+  UPDATE:
+    "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  DELETE:
+    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+};
+
+const changeTypeLabels: Record<string, string> = {
+  CREATE: "新增",
+  UPDATE: "修改",
+  DELETE: "刪除",
+};
+
+export default function HistoryPage() {
+  const [changeType, setChangeType] = useState<string | undefined>();
+  const [changedBy, setChangedBy] = useState("");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+  const [page, setPage] = useState(1);
+  const perPage = 20;
+
+  const { data, pagination, isLoading, error, refetch } = useHistory({
+    changeType: changeType || undefined,
+    changedBy: changedBy || undefined,
+    fromDate: fromDate ? new Date(fromDate).toISOString() : undefined,
+    toDate: toDate ? new Date(toDate + "T23:59:59").toISOString() : undefined,
+    page,
+    perPage,
+  });
+
+  const hasFilters = changeType || changedBy || fromDate || toDate;
+
+  const clearFilters = useCallback(() => {
+    setChangeType(undefined);
+    setChangedBy("");
+    setFromDate("");
+    setToDate("");
+    setPage(1);
+  }, []);
+
+  const handleChangeType = (type: string) => {
+    setChangeType((prev) => (prev === type ? undefined : type));
+    setPage(1);
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      {/* 頁面標題 */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-50">
+            變更歷史
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            追蹤所有 model 設定的變更記錄
+          </p>
+        </div>
+        {pagination && (
+          <span className="text-sm text-slate-500">
+            共 {pagination.total} 筆記錄
+          </span>
+        )}
+      </div>
+
+      {/* 篩選列 */}
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+        {/* 日期範圍 */}
+        <div className="flex items-center gap-2">
+          <Input
+            type="date"
+            value={fromDate}
+            onChange={(e) => {
+              setFromDate(e.target.value);
+              setPage(1);
+            }}
+            className="h-8 w-36 text-sm"
+            placeholder="起始日期"
+          />
+          <span className="text-sm text-slate-400">~</span>
+          <Input
+            type="date"
+            value={toDate}
+            onChange={(e) => {
+              setToDate(e.target.value);
+              setPage(1);
+            }}
+            className="h-8 w-36 text-sm"
+            placeholder="結束日期"
+          />
+        </div>
+
+        {/* 操作者 */}
+        <Input
+          type="text"
+          value={changedBy}
+          onChange={(e) => {
+            setChangedBy(e.target.value);
+            setPage(1);
+          }}
+          className="h-8 w-40 text-sm"
+          placeholder="操作者"
+        />
+
+        {/* 變更類型 toggle */}
+        <div className="flex items-center gap-1.5">
+          {CHANGE_TYPES.map((type) => (
+            <button
+              key={type}
+              onClick={() => handleChangeType(type)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                changeType === type
+                  ? changeTypeBadgeStyles[type]
+                  : "bg-slate-100 text-slate-500 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700"
+              )}
+            >
+              {changeTypeLabels[type]}
+            </button>
+          ))}
+        </div>
+
+        {/* 清除篩選 */}
+        {hasFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearFilters}
+            className="h-8 text-xs text-slate-500"
+          >
+            <X className="mr-1 h-3 w-3" />
+            清除篩選
+          </Button>
+        )}
+      </div>
+
+      {/* 錯誤狀態 */}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={refetch}
+            className="mt-2"
+          >
+            重試
+          </Button>
+        </div>
+      )}
+
+      {/* 時間軸 */}
+      <HistoryTimeline items={data} isLoading={isLoading} />
+
+      {/* 空狀態 */}
+      {!isLoading && !error && data.length === 0 && (
+        <div className="rounded-lg border border-slate-200 bg-white p-12 text-center dark:border-slate-700 dark:bg-slate-900">
+          <p className="text-sm text-slate-500">
+            {hasFilters
+              ? "篩選條件下沒有變更記錄"
+              : "目前沒有任何變更記錄"}
+          </p>
+          {hasFilters && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={clearFilters}
+              className="mt-3"
+            >
+              清除篩選
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* 分頁 */}
+      {pagination && pagination.total_pages > 1 && (
+        <div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 dark:border-slate-700 dark:bg-slate-900">
+          <span className="text-sm text-slate-500">
+            第 {(page - 1) * perPage + 1}-
+            {Math.min(page * perPage, pagination.total)} 筆，共{" "}
+            {pagination.total} 筆
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm text-slate-600 dark:text-slate-400">
+              {page} / {pagination.total_pages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setPage((p) => Math.min(pagination.total_pages, p + 1))
+              }
+              disabled={page >= pagination.total_pages}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dev/src/components/diff-viewer.tsx
+++ b/dev/src/components/diff-viewer.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface DiffViewerProps {
+  /** 舊物件 */
+  oldObj: Record<string, unknown>;
+  /** 新物件 */
+  newObj: Record<string, unknown>;
+  /** 顯示模式：inline 或 side-by-side */
+  mode?: "inline" | "side-by-side";
+}
+
+interface DiffEntry {
+  key: string;
+  type: "added" | "removed" | "changed";
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+function computeDiffEntries(
+  oldObj: Record<string, unknown>,
+  newObj: Record<string, unknown>
+): DiffEntry[] {
+  const allKeys = new Set([...Object.keys(oldObj), ...Object.keys(newObj)]);
+  const entries: DiffEntry[] = [];
+
+  for (const key of allKeys) {
+    const hasOld = key in oldObj;
+    const hasNew = key in newObj;
+
+    if (!hasOld && hasNew) {
+      entries.push({ key, type: "added", newValue: newObj[key] });
+    } else if (hasOld && !hasNew) {
+      entries.push({ key, type: "removed", oldValue: oldObj[key] });
+    } else if (JSON.stringify(oldObj[key]) !== JSON.stringify(newObj[key])) {
+      entries.push({
+        key,
+        type: "changed",
+        oldValue: oldObj[key],
+        newValue: newObj[key],
+      });
+    }
+  }
+
+  return entries;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "(無)";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+const typeStyles: Record<string, string> = {
+  added:
+    "bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-800",
+  removed: "bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-800",
+  changed:
+    "bg-amber-50 border-amber-200 dark:bg-amber-900/20 dark:border-amber-800",
+};
+
+const typeLabels: Record<string, string> = {
+  added: "新增",
+  removed: "刪除",
+  changed: "修改",
+};
+
+const typeTextStyles: Record<string, string> = {
+  added: "text-green-700 dark:text-green-300",
+  removed: "text-red-700 dark:text-red-300",
+  changed: "text-amber-700 dark:text-amber-300",
+};
+
+export function DiffViewer({
+  oldObj,
+  newObj,
+  mode = "inline",
+}: DiffViewerProps) {
+  const entries = computeDiffEntries(oldObj, newObj);
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-slate-500">無差異</p>;
+  }
+
+  if (mode === "inline") {
+    return (
+      <div className="space-y-2" data-testid="diff-viewer">
+        {entries.map((entry) => (
+          <div
+            key={entry.key}
+            className={cn("rounded-md border p-2", typeStyles[entry.type])}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-sm font-medium">{entry.key}</span>
+              <span className={cn("text-xs", typeTextStyles[entry.type])}>
+                {typeLabels[entry.type]}
+              </span>
+            </div>
+            <div className="mt-1 text-sm">
+              {entry.type === "added" && (
+                <span className="text-green-700 dark:text-green-300">
+                  (無) &rarr; {formatValue(entry.newValue)}
+                </span>
+              )}
+              {entry.type === "removed" && (
+                <span className="text-red-700 dark:text-red-300">
+                  {formatValue(entry.oldValue)} &rarr; (已刪除)
+                </span>
+              )}
+              {entry.type === "changed" && (
+                <span className="text-amber-700 dark:text-amber-300">
+                  {formatValue(entry.oldValue)} &rarr;{" "}
+                  {formatValue(entry.newValue)}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // side-by-side mode
+  return (
+    <div
+      className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border"
+      data-testid="diff-viewer"
+    >
+      <div className="bg-red-50/50 p-3 dark:bg-red-900/10">
+        <p className="mb-2 text-xs font-medium text-slate-500">舊值</p>
+        {entries.map((entry) => (
+          <div key={entry.key} className="py-1 font-mono text-sm">
+            <span className="text-slate-500">{entry.key}: </span>
+            <span
+              className={cn(
+                entry.type !== "added"
+                  ? "text-red-700 dark:text-red-300"
+                  : "text-slate-300"
+              )}
+            >
+              {entry.type === "added" ? "—" : formatValue(entry.oldValue)}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="bg-green-50/50 p-3 dark:bg-green-900/10">
+        <p className="mb-2 text-xs font-medium text-slate-500">新值</p>
+        {entries.map((entry) => (
+          <div key={entry.key} className="py-1 font-mono text-sm">
+            <span className="text-slate-500">{entry.key}: </span>
+            <span
+              className={cn(
+                entry.type !== "removed"
+                  ? "text-green-700 dark:text-green-300"
+                  : "text-slate-300"
+              )}
+            >
+              {entry.type === "removed" ? "—" : formatValue(entry.newValue)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dev/src/components/history-timeline.tsx
+++ b/dev/src/components/history-timeline.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DiffViewer } from "./diff-viewer";
+import { formatDistanceToNow } from "date-fns";
+import { zhTW } from "date-fns/locale";
+
+export interface HistoryItem {
+  id: string;
+  model_setting?: {
+    id: string;
+    model_component: { name: string; type: string };
+    environment: { name: string };
+    edition: { name: string };
+  };
+  changed_by: string;
+  change_type: "CREATE" | "UPDATE" | "DELETE";
+  diff: Record<string, { old: unknown; new: unknown }>;
+  reason?: string | null;
+  created_at: string;
+}
+
+interface HistoryTimelineProps {
+  items: HistoryItem[];
+  isLoading?: boolean;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+}
+
+const changeTypeBadge: Record<
+  string,
+  { className: string; label: string }
+> = {
+  CREATE: {
+    className:
+      "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+    label: "新增",
+  },
+  UPDATE: {
+    className:
+      "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+    label: "修改",
+  },
+  DELETE: {
+    className:
+      "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+    label: "刪除",
+  },
+};
+
+function getDiffOld(
+  diff: Record<string, { old: unknown; new: unknown }>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(diff)) {
+    result[key] = value.old;
+  }
+  return result;
+}
+
+function getDiffNew(
+  diff: Record<string, { old: unknown; new: unknown }>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(diff)) {
+    result[key] = value.new;
+  }
+  return result;
+}
+
+export function HistoryTimeline({
+  items,
+  isLoading,
+}: HistoryTimelineProps) {
+  if (isLoading) {
+    return (
+      <div className="relative space-y-0">
+        <div className="absolute left-4 top-0 h-full w-px bg-slate-200 dark:bg-slate-700" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="relative pb-6 pl-10">
+            <div className="absolute left-[13px] top-2 h-2.5 w-2.5 rounded-full border-2 border-white bg-slate-300 dark:border-slate-900 dark:bg-slate-600" />
+            <Card className="border-slate-200 dark:border-slate-700">
+              <CardContent className="p-4">
+                <div className="h-4 w-48 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+                <div className="mt-2 h-3 w-32 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+              </CardContent>
+            </Card>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="relative space-y-0">
+      {/* 時間軸線 */}
+      <div className="absolute left-4 top-0 h-full w-px bg-slate-200 dark:bg-slate-700" />
+
+      {items.map((item) => {
+        const badge = changeTypeBadge[item.change_type];
+        return (
+          <div key={item.id} className="relative pb-6 pl-10">
+            {/* 時間軸圓點 */}
+            <div className="absolute left-[13px] top-2 h-2.5 w-2.5 rounded-full border-2 border-white bg-slate-400 dark:border-slate-900 dark:bg-slate-500" />
+
+            <Collapsible>
+              <Card className="border-slate-200 dark:border-slate-700">
+                <CardContent className="p-4">
+                  {/* 標題列 */}
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">
+                        {item.changed_by}
+                      </span>
+                      {badge && (
+                        <Badge className={cn("text-xs", badge.className)}>
+                          {badge.label}
+                        </Badge>
+                      )}
+                    </div>
+                    <time
+                      className="text-xs text-slate-500"
+                      dateTime={item.created_at}
+                      title={new Date(item.created_at).toLocaleString("zh-TW")}
+                    >
+                      {formatDistanceToNow(new Date(item.created_at), {
+                        addSuffix: true,
+                        locale: zhTW,
+                      })}
+                    </time>
+                  </div>
+
+                  {/* Model 資訊 */}
+                  {item.model_setting && (
+                    <div className="mt-1 flex items-center gap-1.5">
+                      <span className="text-sm text-slate-600 dark:text-slate-400">
+                        {item.model_setting.model_component.name}
+                      </span>
+                      <Badge variant="outline" className="text-xs">
+                        {item.model_setting.environment.name}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs">
+                        {item.model_setting.edition.name}
+                      </Badge>
+                    </div>
+                  )}
+
+                  {/* 展開 diff */}
+                  <CollapsibleTrigger className="mt-2 flex items-center gap-1 text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300">
+                    <ChevronRight className="h-3.5 w-3.5 transition-transform [[data-state=open]>>&]:rotate-90" />
+                    展開查看 diff
+                  </CollapsibleTrigger>
+
+                  <CollapsibleContent className="mt-3">
+                    <DiffViewer
+                      oldObj={getDiffOld(item.diff)}
+                      newObj={getDiffNew(item.diff)}
+                    />
+                    {item.reason && (
+                      <p className="mt-2 text-xs text-slate-500">
+                        原因：{item.reason}
+                      </p>
+                    )}
+                  </CollapsibleContent>
+                </CardContent>
+              </Card>
+            </Collapsible>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dev/src/components/sidebar.tsx
+++ b/dev/src/components/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { LayoutDashboard, Settings2, Table2, GitCompareArrows } from "lucide-react";
+import { LayoutDashboard, Settings2, Table2, GitCompareArrows, History } from "lucide-react";
 
 const navItems = [
   {
@@ -22,6 +22,12 @@ const navItems = [
     name: "版本比較",
     href: "/compare",
     icon: GitCompareArrows,
+    exact: false,
+  },
+  {
+    name: "變更歷史",
+    href: "/history",
+    icon: History,
     exact: false,
   },
 ];

--- a/dev/src/components/ui/collapsible.tsx
+++ b/dev/src/components/ui/collapsible.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/dev/src/hooks/use-history.ts
+++ b/dev/src/hooks/use-history.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import type { HistoryItem } from "@/components/history-timeline";
+
+interface Pagination {
+  page: number;
+  per_page: number;
+  total: number;
+  total_pages: number;
+}
+
+interface HistoryResponse {
+  data: HistoryItem[];
+  pagination: Pagination;
+}
+
+export interface UseHistoryParams {
+  versionId?: string;
+  environmentId?: string;
+  editionId?: string;
+  modelComponentId?: string;
+  changedBy?: string;
+  changeType?: string;
+  fromDate?: string;
+  toDate?: string;
+  page?: number;
+  perPage?: number;
+}
+
+interface UseHistoryResult {
+  data: HistoryItem[];
+  pagination: Pagination | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useHistory(params: UseHistoryParams): UseHistoryResult {
+  const [data, setData] = useState<HistoryItem[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    const searchParams = new URLSearchParams();
+    if (params.versionId) searchParams.set("version_id", params.versionId);
+    if (params.environmentId)
+      searchParams.set("environment_id", params.environmentId);
+    if (params.editionId) searchParams.set("edition_id", params.editionId);
+    if (params.modelComponentId)
+      searchParams.set("model_component_id", params.modelComponentId);
+    if (params.changedBy) searchParams.set("changed_by", params.changedBy);
+    if (params.changeType) searchParams.set("change_type", params.changeType);
+    if (params.fromDate) searchParams.set("from_date", params.fromDate);
+    if (params.toDate) searchParams.set("to_date", params.toDate);
+    if (params.page) searchParams.set("page", String(params.page));
+    if (params.perPage) searchParams.set("per_page", String(params.perPage));
+
+    try {
+      const res = await fetch(`/api/v1/history?${searchParams.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message || `HTTP ${res.status}`);
+      }
+      const result: HistoryResponse = await res.json();
+      setData(result.data);
+      setPagination(result.pagination);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setData([]);
+      setPagination(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    params.versionId,
+    params.environmentId,
+    params.editionId,
+    params.modelComponentId,
+    params.changedBy,
+    params.changeType,
+    params.fromDate,
+    params.toDate,
+    params.page,
+    params.perPage,
+  ]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  return { data, pagination, isLoading, error, refetch: fetchHistory };
+}

--- a/dev/src/lib/queries/history.ts
+++ b/dev/src/lib/queries/history.ts
@@ -1,0 +1,250 @@
+import { db } from "@/db";
+import {
+  changeHistories,
+  modelSettings,
+  modelComponents,
+  environments,
+  editions,
+} from "@/db/schema";
+import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
+
+export interface HistoryQueryParams {
+  versionId?: string;
+  environmentId?: string;
+  editionId?: string;
+  modelComponentId?: string;
+  changedBy?: string;
+  changeType?: string;
+  fromDate?: string;
+  toDate?: string;
+  page: number;
+  perPage: number;
+}
+
+export async function queryHistory(params: HistoryQueryParams) {
+  const {
+    versionId,
+    environmentId,
+    editionId,
+    modelComponentId,
+    changedBy,
+    changeType,
+    fromDate,
+    toDate,
+    page,
+    perPage,
+  } = params;
+
+  const conditions = [];
+
+  if (versionId) {
+    conditions.push(eq(modelComponents.versionId, versionId));
+  }
+  if (environmentId) {
+    conditions.push(eq(modelSettings.environmentId, environmentId));
+  }
+  if (editionId) {
+    conditions.push(eq(modelSettings.editionId, editionId));
+  }
+  if (modelComponentId) {
+    conditions.push(eq(modelSettings.modelComponentId, modelComponentId));
+  }
+  if (changedBy) {
+    conditions.push(eq(changeHistories.changedBy, changedBy));
+  }
+  if (changeType) {
+    conditions.push(eq(changeHistories.changeType, changeType));
+  }
+  if (fromDate) {
+    conditions.push(gte(changeHistories.createdAt, new Date(fromDate)));
+  }
+  if (toDate) {
+    conditions.push(lte(changeHistories.createdAt, new Date(toDate)));
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [data, countResult] = await Promise.all([
+    db
+      .select({
+        id: changeHistories.id,
+        modelSettingId: modelSettings.id,
+        modelComponentName: modelComponents.name,
+        modelComponentType: modelComponents.type,
+        componentVersion: modelComponents.componentVersion,
+        environmentName: environments.name,
+        editionName: editions.name,
+        changedBy: changeHistories.changedBy,
+        changeType: changeHistories.changeType,
+        diff: changeHistories.diff,
+        reason: changeHistories.reason,
+        createdAt: changeHistories.createdAt,
+      })
+      .from(changeHistories)
+      .innerJoin(
+        modelSettings,
+        eq(changeHistories.modelSettingId, modelSettings.id)
+      )
+      .innerJoin(
+        modelComponents,
+        eq(modelSettings.modelComponentId, modelComponents.id)
+      )
+      .innerJoin(
+        environments,
+        eq(modelSettings.environmentId, environments.id)
+      )
+      .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+      .where(whereClause)
+      .orderBy(desc(changeHistories.createdAt))
+      .limit(perPage)
+      .offset((page - 1) * perPage),
+
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(changeHistories)
+      .innerJoin(
+        modelSettings,
+        eq(changeHistories.modelSettingId, modelSettings.id)
+      )
+      .innerJoin(
+        modelComponents,
+        eq(modelSettings.modelComponentId, modelComponents.id)
+      )
+      .innerJoin(
+        environments,
+        eq(modelSettings.environmentId, environments.id)
+      )
+      .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+      .where(whereClause),
+  ]);
+
+  const total = countResult[0]?.count ?? 0;
+
+  return {
+    data: data.map((row) => ({
+      id: row.id,
+      model_setting: {
+        id: row.modelSettingId,
+        model_component: {
+          name: row.modelComponentName,
+          type: row.modelComponentType,
+        },
+        environment: { name: row.environmentName },
+        edition: { name: row.editionName },
+      },
+      changed_by: row.changedBy,
+      change_type: row.changeType,
+      diff: row.diff,
+      reason: row.reason,
+      created_at: row.createdAt.toISOString(),
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total,
+      total_pages: Math.ceil(total / perPage) || 1,
+    },
+  };
+}
+
+export async function getHistoryById(historyId: string) {
+  const result = await db
+    .select({
+      id: changeHistories.id,
+      modelSettingId: modelSettings.id,
+      modelComponentName: modelComponents.name,
+      modelComponentType: modelComponents.type,
+      componentVersion: modelComponents.componentVersion,
+      environmentId: environments.id,
+      environmentName: environments.name,
+      editionId: editions.id,
+      editionName: editions.name,
+      changedBy: changeHistories.changedBy,
+      changeType: changeHistories.changeType,
+      diff: changeHistories.diff,
+      reason: changeHistories.reason,
+      createdAt: changeHistories.createdAt,
+    })
+    .from(changeHistories)
+    .innerJoin(
+      modelSettings,
+      eq(changeHistories.modelSettingId, modelSettings.id)
+    )
+    .innerJoin(
+      modelComponents,
+      eq(modelSettings.modelComponentId, modelComponents.id)
+    )
+    .innerJoin(environments, eq(modelSettings.environmentId, environments.id))
+    .innerJoin(editions, eq(modelSettings.editionId, editions.id))
+    .where(eq(changeHistories.id, historyId))
+    .limit(1);
+
+  if (result.length === 0) return null;
+
+  const row = result[0];
+  return {
+    id: row.id,
+    model_setting: {
+      id: row.modelSettingId,
+      model_component: {
+        name: row.modelComponentName,
+        type: row.modelComponentType,
+        component_version: row.componentVersion,
+      },
+      environment: { id: row.environmentId, name: row.environmentName },
+      edition: { id: row.editionId, name: row.editionName },
+    },
+    changed_by: row.changedBy,
+    change_type: row.changeType,
+    diff: row.diff,
+    reason: row.reason,
+    created_at: row.createdAt.toISOString(),
+  };
+}
+
+export async function getSettingHistory(
+  settingId: string,
+  page: number,
+  perPage: number
+) {
+  const [data, countResult] = await Promise.all([
+    db
+      .select({
+        id: changeHistories.id,
+        changedBy: changeHistories.changedBy,
+        changeType: changeHistories.changeType,
+        diff: changeHistories.diff,
+        reason: changeHistories.reason,
+        createdAt: changeHistories.createdAt,
+      })
+      .from(changeHistories)
+      .where(eq(changeHistories.modelSettingId, settingId))
+      .orderBy(desc(changeHistories.createdAt))
+      .limit(perPage)
+      .offset((page - 1) * perPage),
+
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(changeHistories)
+      .where(eq(changeHistories.modelSettingId, settingId)),
+  ]);
+
+  const total = countResult[0]?.count ?? 0;
+
+  return {
+    data: data.map((row) => ({
+      id: row.id,
+      changed_by: row.changedBy,
+      change_type: row.changeType,
+      diff: row.diff,
+      reason: row.reason,
+      created_at: row.createdAt.toISOString(),
+    })),
+    pagination: {
+      page,
+      per_page: perPage,
+      total,
+      total_pages: Math.ceil(total / perPage) || 1,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- GET /api/v1/history — 全域歷史 API，支援 version/environment/edition/component/user/type/date 多維篩選 + 分頁
- GET /api/v1/history/:id — 單筆歷史詳情含完整 diff
- GET /api/v1/settings/:settingId/history — 單一 setting 的變更歷史（先驗證 setting 存在）
- `/history` 頁面：時間軸列表 + 篩選列（日期範圍、操作者、變更類型 toggle）+ 分頁
- DiffViewer 元件：inline / side-by-side 兩種模式，field-level color-coded diff
- HistoryTimeline 元件：Collapsible 展開查看 diff + reason
- Sidebar 新增「變更歷史」導航連結
- 14 項 unit tests 全部通過

Closes #10

## Test plan
- [ ] `GET /api/v1/history` 無篩選回傳全部歷史（按 created_at 倒序）
- [ ] 各篩選參數（version_id, change_type, changed_by, date range）正確過濾
- [ ] `GET /api/v1/history/:id` 回傳完整 diff + model_setting 資訊
- [ ] `GET /api/v1/settings/:settingId/history` 404 for non-existent setting
- [ ] `/history` 頁面正常顯示時間軸
- [ ] 篩選切換後 page 重置為 1
- [ ] DiffViewer 正確標示 added/removed/changed
- [ ] Collapsible 展開/收合正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)