### PR TITLE
fix: Sprint 2 驗證問題修復

### DIFF
--- a/dev/src/app/api/v1/compare/route.ts
+++ b/dev/src/app/api/v1/compare/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { successResponse, errorResponse } from "@/lib/api";
-import { compareVersions, CompareError } from "@/lib/queries/compare";
+import { compareVersions } from "@/lib/queries/compare";
+import { ApiError } from "@/lib/api-error";
 
 const compareQuerySchema = z
   .object({
@@ -49,7 +50,7 @@ export async function GET(request: NextRequest) {
 
     return successResponse(result);
   } catch (error) {
-    if (error instanceof CompareError) {
+    if (error instanceof ApiError) {
       return errorResponse(error.code, error.message, error.status);
     }
     console.error("Failed to compare versions:", error);

--- a/dev/src/app/api/v1/settings/[settingId]/route.ts
+++ b/dev/src/app/api/v1/settings/[settingId]/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { successResponse, errorResponse } from "@/lib/api";
-import { getSettingById, updateSetting, UpdateSettingError } from "@/lib/queries/settings";
+import { getSettingById, updateSetting } from "@/lib/queries/settings";
+import { ApiError } from "@/lib/api-error";
 
 export async function GET(
   _request: NextRequest,
@@ -89,7 +90,7 @@ export async function PATCH(
       change_history_id: result.changeHistoryId,
     });
   } catch (error) {
-    if (error instanceof UpdateSettingError) {
+    if (error instanceof ApiError) {
       return errorResponse(error.code, error.message, error.status);
     }
     console.error("Failed to update setting:", error);

--- a/dev/src/app/api/v1/settings/batch/route.ts
+++ b/dev/src/app/api/v1/settings/batch/route.ts
@@ -1,0 +1,214 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { successResponse, errorResponse } from "@/lib/api";
+import { ApiError } from "@/lib/api-error";
+import { db } from "@/db";
+import {
+  modelSettings,
+  changeHistories,
+} from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { computeDiff } from "@/lib/diff";
+import { getSettingById } from "@/lib/queries/settings";
+
+const MAX_BATCH_SIZE = 50;
+
+const batchSettingItemSchema = z.object({
+  id: z.string().uuid("id must be a valid UUID"),
+  settings: z.object({
+    deploy: z.boolean().optional(),
+    gpu_list: z.array(z.string().max(50)).optional(),
+    replica: z.number().int().min(0).optional(),
+    gpu_memory_utilization: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .transform((v) =>
+        v !== undefined ? Math.round(v * 100) / 100 : undefined
+      ),
+    extra_settings: z.record(z.unknown()).optional(),
+  }),
+  reason: z.string().max(500).optional(),
+  expected_updated_at: z.string().optional(),
+});
+
+const batchPatchSchema = z.object({
+  settings: z
+    .array(batchSettingItemSchema)
+    .min(1, "At least one setting is required")
+    .max(MAX_BATCH_SIZE, `Maximum ${MAX_BATCH_SIZE} settings per batch`),
+  changed_by: z.string().max(100),
+});
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const parseResult = batchPatchSchema.safeParse(body);
+    if (!parseResult.success) {
+      return errorResponse(
+        "INVALID_INPUT",
+        parseResult.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", "),
+        400
+      );
+    }
+
+    const { settings: items, changed_by } = parseResult.data;
+
+    // 1. Validate all settings exist before starting transaction
+    const currentRowsMap = new Map<
+      string,
+      typeof modelSettings.$inferSelect
+    >();
+
+    for (const item of items) {
+      const rows = await db
+        .select()
+        .from(modelSettings)
+        .where(eq(modelSettings.id, item.id))
+        .limit(1);
+
+      if (rows.length === 0) {
+        return errorResponse(
+          "NOT_FOUND",
+          `Setting not found: ${item.id}`,
+          404
+        );
+      }
+      currentRowsMap.set(item.id, rows[0]);
+    }
+
+    // 2. Validate optimistic locks and compute diffs
+    const updates: Array<{
+      item: (typeof items)[number];
+      current: typeof modelSettings.$inferSelect;
+      diff: Record<string, { old: unknown; new: unknown }>;
+      changeHistoryId: string;
+    }> = [];
+
+    for (const item of items) {
+      const current = currentRowsMap.get(item.id)!;
+
+      // Optimistic lock check
+      if (item.expected_updated_at) {
+        const expected = new Date(item.expected_updated_at).getTime();
+        const actual = current.updatedAt.getTime();
+        if (expected !== actual) {
+          return errorResponse(
+            "CONFLICT",
+            `Setting ${item.id} has been modified by another user. Please refresh and try again.`,
+            409
+          );
+        }
+      }
+
+      // Compute diff
+      const oldValues: Record<string, unknown> = {};
+      const newValues: Record<string, unknown> = {};
+      const changes = item.settings;
+
+      if (changes.deploy !== undefined) {
+        oldValues.deploy = current.deploy;
+        newValues.deploy = changes.deploy;
+      }
+      if (changes.gpu_list !== undefined) {
+        oldValues.gpu_list = current.gpuList ?? [];
+        newValues.gpu_list = changes.gpu_list;
+      }
+      if (changes.replica !== undefined) {
+        oldValues.replica = current.replica;
+        newValues.replica = changes.replica;
+      }
+      if (changes.gpu_memory_utilization !== undefined) {
+        oldValues.gpu_memory_utilization =
+          current.gpuMemoryUtilization !== null
+            ? parseFloat(current.gpuMemoryUtilization)
+            : null;
+        newValues.gpu_memory_utilization = changes.gpu_memory_utilization;
+      }
+      if (changes.extra_settings !== undefined) {
+        oldValues.extra_settings = current.extraSettings ?? {};
+        newValues.extra_settings = changes.extra_settings;
+      }
+
+      const diff = computeDiff(oldValues, newValues);
+
+      if (Object.keys(diff).length === 0) {
+        return errorResponse(
+          "INVALID_INPUT",
+          `No changes detected for setting ${item.id} - submitted values are identical to current values`,
+          400
+        );
+      }
+
+      updates.push({
+        item,
+        current,
+        diff,
+        changeHistoryId: crypto.randomUUID(),
+      });
+    }
+
+    // 3. Transaction: batch update all settings + insert change histories
+    const now = new Date();
+
+    await db.transaction(async (tx) => {
+      for (const { item, diff, changeHistoryId } of updates) {
+        const changes = item.settings;
+        const updateData: Record<string, unknown> = { updatedAt: now };
+
+        if (changes.deploy !== undefined) updateData.deploy = changes.deploy;
+        if (changes.gpu_list !== undefined)
+          updateData.gpuList = changes.gpu_list;
+        if (changes.replica !== undefined) updateData.replica = changes.replica;
+        if (changes.gpu_memory_utilization !== undefined) {
+          updateData.gpuMemoryUtilization = String(
+            changes.gpu_memory_utilization
+          );
+        }
+        if (changes.extra_settings !== undefined)
+          updateData.extraSettings = changes.extra_settings;
+
+        await tx
+          .update(modelSettings)
+          .set(updateData)
+          .where(eq(modelSettings.id, item.id));
+
+        await tx.insert(changeHistories).values({
+          id: changeHistoryId,
+          modelSettingId: item.id,
+          changedBy: changed_by,
+          changeType: "UPDATE",
+          diff,
+          reason: item.reason || null,
+        });
+      }
+    });
+
+    // 4. Fetch updated settings
+    const updated = await Promise.all(
+      updates.map(async ({ item, changeHistoryId }) => {
+        const setting = await getSettingById(item.id);
+        return {
+          ...setting,
+          change_history_id: changeHistoryId,
+        };
+      })
+    );
+
+    return successResponse({ updated, failed: [] });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return errorResponse(error.code, error.message, error.status);
+    }
+    console.error("Failed to batch update settings:", error);
+    return errorResponse(
+      "INTERNAL_ERROR",
+      "Failed to batch update settings",
+      500
+    );
+  }
+}

--- a/dev/src/lib/api-error.ts
+++ b/dev/src/lib/api-error.ts
@@ -1,6 +1,7 @@
 export const ErrorCodes = {
   INVALID_INPUT: { code: "INVALID_INPUT", status: 400 },
   NOT_FOUND: { code: "NOT_FOUND", status: 404 },
+  CONFLICT: { code: "CONFLICT", status: 409 },
   DUPLICATE: { code: "DUPLICATE", status: 409 },
   PARSE_ERROR: { code: "PARSE_ERROR", status: 422 },
   INTERNAL_ERROR: { code: "INTERNAL_ERROR", status: 500 },

--- a/dev/src/lib/diff.ts
+++ b/dev/src/lib/diff.ts
@@ -23,7 +23,7 @@ export function computeDiff(
 /**
  * 深度相等比較（支援 primitive, array, object）
  */
-function isEqual(a: unknown, b: unknown): boolean {
+export function isEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a === null || b === null) return false;
   if (a === undefined || b === undefined) return false;

--- a/dev/src/lib/queries/compare.ts
+++ b/dev/src/lib/queries/compare.ts
@@ -7,6 +7,8 @@ import {
   versions,
 } from "@/db/schema";
 import { eq, and, sql } from "drizzle-orm";
+import { isEqual } from "@/lib/diff";
+import { ApiError } from "@/lib/api-error";
 
 export interface CompareParams {
   versionAId: string;
@@ -70,30 +72,6 @@ function getFieldValue(record: SettingRecord, field: string): unknown {
   }
 }
 
-function isEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return a === b;
-  if (a === undefined || b === undefined) return a === b;
-  if (typeof a !== typeof b) return false;
-
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((val, i) => isEqual(val, b[i]));
-  }
-
-  if (typeof a === "object" && typeof b === "object") {
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
-    for (const key of keys) {
-      if (!isEqual(aObj[key], bObj[key])) return false;
-    }
-    return true;
-  }
-
-  return false;
-}
-
 async function getSettingsForVersion(
   versionId: string,
   environmentId?: string,
@@ -138,7 +116,7 @@ async function getSettingsForVersion(
     deploy: r.deploy,
     gpuList: (r.gpuList as string[]) ?? [],
     replica: r.replica,
-    gpuMemoryUtilization: r.gpuMemoryUtilization
+    gpuMemoryUtilization: r.gpuMemoryUtilization !== null
       ? parseFloat(r.gpuMemoryUtilization)
       : null,
     extraSettings: (r.extraSettings as Record<string, unknown>) ?? {},
@@ -155,10 +133,10 @@ export async function compareVersions(params: CompareParams) {
   ]);
 
   if (versionA.length === 0) {
-    throw new CompareError("NOT_FOUND", `Version A not found: ${versionAId}`, 404);
+    throw new ApiError("NOT_FOUND", `Version A not found: ${versionAId}`);
   }
   if (versionB.length === 0) {
-    throw new CompareError("NOT_FOUND", `Version B not found: ${versionBId}`, 404);
+    throw new ApiError("NOT_FOUND", `Version B not found: ${versionBId}`);
   }
 
   // 2. Get settings for both versions
@@ -259,12 +237,3 @@ export async function compareVersions(params: CompareParams) {
   };
 }
 
-export class CompareError extends Error {
-  code: string;
-  status: number;
-  constructor(code: string, message: string, status: number) {
-    super(message);
-    this.code = code;
-    this.status = status;
-  }
-}

--- a/dev/src/lib/queries/settings.ts
+++ b/dev/src/lib/queries/settings.ts
@@ -8,6 +8,7 @@ import {
 } from "@/db/schema";
 import { eq, and, ilike, sql, asc, desc } from "drizzle-orm";
 import { computeDiff } from "@/lib/diff";
+import { ApiError } from "@/lib/api-error";
 
 export interface SettingsQueryParams {
   versionId: string;
@@ -191,7 +192,7 @@ export async function querySettings(params: SettingsQueryParams) {
       deploy: row.deploy,
       gpu_list: row.gpuList ?? [],
       replica: row.replica,
-      gpu_memory_utilization: row.gpuMemoryUtilization
+      gpu_memory_utilization: row.gpuMemoryUtilization !== null
         ? parseFloat(row.gpuMemoryUtilization)
         : null,
       extra_settings: row.extraSettings ?? {},
@@ -265,7 +266,7 @@ export async function getSettingById(settingId: string) {
     deploy: row.deploy,
     gpu_list: row.gpuList ?? [],
     replica: row.replica,
-    gpu_memory_utilization: row.gpuMemoryUtilization
+    gpu_memory_utilization: row.gpuMemoryUtilization !== null
       ? parseFloat(row.gpuMemoryUtilization)
       : null,
     extra_settings: row.extraSettings ?? {},
@@ -297,7 +298,7 @@ export async function updateSetting(
     .limit(1);
 
   if (currentRows.length === 0) {
-    throw new UpdateSettingError("NOT_FOUND", "Setting not found", 404);
+    throw new ApiError("NOT_FOUND", "Setting not found");
   }
 
   const current = currentRows[0];
@@ -307,10 +308,9 @@ export async function updateSetting(
     const expected = new Date(expectedUpdatedAt).getTime();
     const actual = current.updatedAt.getTime();
     if (expected !== actual) {
-      throw new UpdateSettingError(
+      throw new ApiError(
         "CONFLICT",
-        "Setting has been modified by another user. Please refresh and try again.",
-        409
+        "Setting has been modified by another user. Please refresh and try again."
       );
     }
   }
@@ -332,7 +332,7 @@ export async function updateSetting(
     newValues.replica = changes.replica;
   }
   if (changes.gpu_memory_utilization !== undefined) {
-    oldValues.gpu_memory_utilization = current.gpuMemoryUtilization
+    oldValues.gpu_memory_utilization = current.gpuMemoryUtilization !== null
       ? parseFloat(current.gpuMemoryUtilization)
       : null;
     newValues.gpu_memory_utilization = changes.gpu_memory_utilization;
@@ -345,10 +345,9 @@ export async function updateSetting(
   const diff = computeDiff(oldValues, newValues);
 
   if (Object.keys(diff).length === 0) {
-    throw new UpdateSettingError(
+    throw new ApiError(
       "INVALID_INPUT",
-      "No changes detected - submitted values are identical to current values",
-      400
+      "No changes detected - submitted values are identical to current values"
     );
   }
 
@@ -386,12 +385,3 @@ export async function updateSetting(
   return { setting: setting!, changeHistoryId };
 }
 
-export class UpdateSettingError extends Error {
-  code: string;
-  status: number;
-  constructor(code: string, message: string, status: number) {
-    super(message);
-    this.code = code;
-    this.status = status;
-  }
-}


### PR DESCRIPTION
## Summary
- 新增 PATCH /api/v1/settings/batch 批量編輯 endpoint（transaction 原子操作，上限 50 筆）
- 修正 gpu_memory_utilization=0 的 falsy 判斷 bug（4 處 `? parseFloat(...)` 改為 `!== null`）
- 統一使用共用 ApiError class（移除 UpdateSettingError, CompareError）
- 共用 isEqual() 函式，移除 compare.ts 的重複實作

## Fixes
- Batch edit: 4 個 E2E test 不再失敗
- gpu_memory_utilization: 值為 0 時正確存入而非被轉為 null
- Error handling: 統一錯誤處理風格，所有 route handler 使用 ApiError

## 影響檔案
- `dev/src/app/api/v1/settings/batch/route.ts` — 新增
- `dev/src/lib/api-error.ts` — 新增 CONFLICT error code
- `dev/src/lib/diff.ts` — export isEqual
- `dev/src/lib/queries/settings.ts` — 修正 falsy bug + 移除 UpdateSettingError
- `dev/src/lib/queries/compare.ts` — 修正 falsy bug + 移除 CompareError + 使用共用 isEqual
- `dev/src/app/api/v1/settings/[settingId]/route.ts` — 改用 ApiError
- `dev/src/app/api/v1/compare/route.ts` — 改用 ApiError